### PR TITLE
update circleci rustc version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
     CPPFLAGS: "-I$HOME/.local/include"
     CXXFLAGS: "-I$HOME/.local/include"
     PKG_CONFIG_PATH: "$PKG_CONFIG_PATH:$HOME/.local/lib/pkgconfig"
-    RUSTC_DATE: "2017-03-28"
+    RUSTC_DATE: "2017-08-09"
     LOCAL_PREFIX: "$HOME/.local"
     # used by cargo
     LIBRARY_PATH: "$LIBRARY_PATH:$HOME/.local/lib"


### PR DESCRIPTION
currently ci failed with:
```
   Compiling grpcio v0.1.1
$<2>error$<2>$<2>: use of unstable library feature 'thread_id' (see issue #21507)$<2>
  $<2>$<2>--> $<2>/home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/grpcio-0.1.1/src/async/executor.rs:16:25$<2>
   $<2>$<2>|$<2>
$<2>16$<2> $<2>$<2>| $<2>use std::thread::{self, ThreadId};$<2>
   $<2>$<2>| $<2>                        $<2>$<2>^^^^^^^^$<2>
   $<2>$<2>|$<2>
   $<2>$<2>= $<2>$<2>help$<2>: add #![feature(thread_id)] to the crate attributes to enable$<2>

$<2>error$<2>$<2>: use of unstable library feature 'thread_id' (see issue #21507)$<2>
  $<2>$<2>--> $<2>/home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/grpcio-0.1.1/src/cq.rs:17:5$<2>
   $<2>$<2>|$<2>
$<2>17$<2> $<2>$<2>| $<2>use std::thread::ThreadId;$<2>
   $<2>$<2>| $<2>    $<2>$<2>^^^^^^^^^^^^^^^^^^^^^$<2>
   $<2>$<2>|$<2>
   $<2>$<2>= $<2>$<2>help$<2>: add #![feature(thread_id)] to the crate attributes to enable$<2>

$<2>error$<2>$<2>: use of unstable library feature 'thread_id' (see issue #21507)$<2>
  $<2>$<2>--> $<2>/home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/grpcio-0.1.1/src/async/executor.rs:97:16$<2>
   $<2>$<2>|$<2>
$<2>97$<2> $<2>$<2>| $<2>    worker_id: ThreadId,$<2>
   $<2>$<2>| $<2>               $<2>$<2>^^^^^^^^$<2>
   $<2>$<2>|$<2>
   $<2>$<2>= $<2>$<2>help$<2>: add #![feature(thread_id)] to the crate attributes to enable$<2>
```