### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/_vendor	linguist-vendored
+/pkg		linguist-generated
+/src		linguist-generated
+


### PR DESCRIPTION
- Automatically suppress diff for our generated files when reviewing PRs.
- Exclude generated files and vendor files from the GitHub's language detection.

Fix #256