### PR TITLE
Fix .gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/_vendor	linguist-vendored
-/pkg		linguist-generated
-/src		linguist-generated
-
+_vendor/**  linguist-vendored
+pkg/**      linguist-generated
+src/**      linguist-generated


### PR DESCRIPTION
Previous PR is https://github.com/pingcap/kvproto/pull/260  but it is not working.

According to [git-scm](https://git-scm.com/docs/gitattributes), we may need to replace directories with `foo/**` style. Hope it works.

@Hoverbear PTAL