### PR TITLE
Makefile: fix make rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ go: init
 	GO111MODULE=on go build ./pkg/...
 
 rust: init
-	cargo check
+	cargo check --features regenerate
 
 .PHONY: all


### PR DESCRIPTION
Signed-off-by: AndreMouche <AndreMouche@126.com>

Hi,
      This PR will fix the command `make rust` which is used to generate code for rust.

@overvenus @hicqu PTAL