### PR TITLE
Revert "Make debug format pretty again (#377)"

### DIFF
--- a/pkg/coprocessor/coprocessor.pb.go
+++ b/pkg/coprocessor/coprocessor.pb.go
@@ -43,7 +43,7 @@ func (m *KeyRange) Reset()         { *m = KeyRange{} }
 func (m *KeyRange) String() string { return proto.CompactTextString(m) }
 func (*KeyRange) ProtoMessage()    {}
 func (*KeyRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_coprocessor_48290ccf34cc5842, []int{0}
+	return fileDescriptor_coprocessor_3dad05e5ee8aa59e, []int{0}
 }
 func (m *KeyRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -100,7 +100,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_coprocessor_48290ccf34cc5842, []int{1}
+	return fileDescriptor_coprocessor_3dad05e5ee8aa59e, []int{1}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -173,7 +173,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_coprocessor_48290ccf34cc5842, []int{2}
+	return fileDescriptor_coprocessor_3dad05e5ee8aa59e, []int{2}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1125,9 +1125,9 @@ var (
 	ErrIntOverflowCoprocessor   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("coprocessor.proto", fileDescriptor_coprocessor_48290ccf34cc5842) }
+func init() { proto.RegisterFile("coprocessor.proto", fileDescriptor_coprocessor_3dad05e5ee8aa59e) }
 
-var fileDescriptor_coprocessor_48290ccf34cc5842 = []byte{
+var fileDescriptor_coprocessor_3dad05e5ee8aa59e = []byte{
 	// 436 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x50, 0xbb, 0x6e, 0x13, 0x41,
 	0x14, 0xcd, 0xfa, 0x15, 0x73, 0xd7, 0x09, 0xce, 0xc8, 0x48, 0xab, 0x14, 0xb6, 0xe5, 0x02, 0x19,

--- a/pkg/debugpb/debugpb.pb.go
+++ b/pkg/debugpb/debugpb.pb.go
@@ -57,7 +57,7 @@ func (x DB) String() string {
 	return proto.EnumName(DB_name, int32(x))
 }
 func (DB) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{0}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{0}
 }
 
 type MODULE int32
@@ -107,7 +107,7 @@ func (x MODULE) String() string {
 	return proto.EnumName(MODULE_name, int32(x))
 }
 func (MODULE) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{1}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{1}
 }
 
 type BottommostLevelCompaction int32
@@ -136,7 +136,7 @@ func (x BottommostLevelCompaction) String() string {
 	return proto.EnumName(BottommostLevelCompaction_name, int32(x))
 }
 func (BottommostLevelCompaction) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{2}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{2}
 }
 
 type GetRequest struct {
@@ -152,7 +152,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{0}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{0}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -213,7 +213,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{1}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{1}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -261,7 +261,7 @@ func (m *RaftLogRequest) Reset()         { *m = RaftLogRequest{} }
 func (m *RaftLogRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftLogRequest) ProtoMessage()    {}
 func (*RaftLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{2}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{2}
 }
 func (m *RaftLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -315,7 +315,7 @@ func (m *RaftLogResponse) Reset()         { *m = RaftLogResponse{} }
 func (m *RaftLogResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftLogResponse) ProtoMessage()    {}
 func (*RaftLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{3}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{3}
 }
 func (m *RaftLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -362,7 +362,7 @@ func (m *RegionInfoRequest) Reset()         { *m = RegionInfoRequest{} }
 func (m *RegionInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionInfoRequest) ProtoMessage()    {}
 func (*RegionInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{4}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{4}
 }
 func (m *RegionInfoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -411,7 +411,7 @@ func (m *RegionInfoResponse) Reset()         { *m = RegionInfoResponse{} }
 func (m *RegionInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionInfoResponse) ProtoMessage()    {}
 func (*RegionInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{5}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{5}
 }
 func (m *RegionInfoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -473,7 +473,7 @@ func (m *RegionSizeRequest) Reset()         { *m = RegionSizeRequest{} }
 func (m *RegionSizeRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionSizeRequest) ProtoMessage()    {}
 func (*RegionSizeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{6}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{6}
 }
 func (m *RegionSizeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -527,7 +527,7 @@ func (m *RegionSizeResponse) Reset()         { *m = RegionSizeResponse{} }
 func (m *RegionSizeResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionSizeResponse) ProtoMessage()    {}
 func (*RegionSizeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{7}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{7}
 }
 func (m *RegionSizeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -575,7 +575,7 @@ func (m *RegionSizeResponse_Entry) Reset()         { *m = RegionSizeResponse_Ent
 func (m *RegionSizeResponse_Entry) String() string { return proto.CompactTextString(m) }
 func (*RegionSizeResponse_Entry) ProtoMessage()    {}
 func (*RegionSizeResponse_Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{7, 0}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{7, 0}
 }
 func (m *RegionSizeResponse_Entry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -631,7 +631,7 @@ func (m *ScanMvccRequest) Reset()         { *m = ScanMvccRequest{} }
 func (m *ScanMvccRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanMvccRequest) ProtoMessage()    {}
 func (*ScanMvccRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{8}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{8}
 }
 func (m *ScanMvccRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -693,7 +693,7 @@ func (m *ScanMvccResponse) Reset()         { *m = ScanMvccResponse{} }
 func (m *ScanMvccResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanMvccResponse) ProtoMessage()    {}
 func (*ScanMvccResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{9}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{9}
 }
 func (m *ScanMvccResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -752,7 +752,7 @@ func (m *CompactRequest) Reset()         { *m = CompactRequest{} }
 func (m *CompactRequest) String() string { return proto.CompactTextString(m) }
 func (*CompactRequest) ProtoMessage()    {}
 func (*CompactRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{10}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{10}
 }
 func (m *CompactRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -833,7 +833,7 @@ func (m *CompactResponse) Reset()         { *m = CompactResponse{} }
 func (m *CompactResponse) String() string { return proto.CompactTextString(m) }
 func (*CompactResponse) ProtoMessage()    {}
 func (*CompactResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{11}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{11}
 }
 func (m *CompactResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -874,7 +874,7 @@ func (m *InjectFailPointRequest) Reset()         { *m = InjectFailPointRequest{}
 func (m *InjectFailPointRequest) String() string { return proto.CompactTextString(m) }
 func (*InjectFailPointRequest) ProtoMessage()    {}
 func (*InjectFailPointRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{12}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{12}
 }
 func (m *InjectFailPointRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -927,7 +927,7 @@ func (m *InjectFailPointResponse) Reset()         { *m = InjectFailPointResponse
 func (m *InjectFailPointResponse) String() string { return proto.CompactTextString(m) }
 func (*InjectFailPointResponse) ProtoMessage()    {}
 func (*InjectFailPointResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{13}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{13}
 }
 func (m *InjectFailPointResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -967,7 +967,7 @@ func (m *RecoverFailPointRequest) Reset()         { *m = RecoverFailPointRequest
 func (m *RecoverFailPointRequest) String() string { return proto.CompactTextString(m) }
 func (*RecoverFailPointRequest) ProtoMessage()    {}
 func (*RecoverFailPointRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{14}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{14}
 }
 func (m *RecoverFailPointRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1013,7 +1013,7 @@ func (m *RecoverFailPointResponse) Reset()         { *m = RecoverFailPointRespon
 func (m *RecoverFailPointResponse) String() string { return proto.CompactTextString(m) }
 func (*RecoverFailPointResponse) ProtoMessage()    {}
 func (*RecoverFailPointResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{15}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{15}
 }
 func (m *RecoverFailPointResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1052,7 +1052,7 @@ func (m *ListFailPointsRequest) Reset()         { *m = ListFailPointsRequest{} }
 func (m *ListFailPointsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListFailPointsRequest) ProtoMessage()    {}
 func (*ListFailPointsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{16}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{16}
 }
 func (m *ListFailPointsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1092,7 +1092,7 @@ func (m *ListFailPointsResponse) Reset()         { *m = ListFailPointsResponse{}
 func (m *ListFailPointsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListFailPointsResponse) ProtoMessage()    {}
 func (*ListFailPointsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{17}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{17}
 }
 func (m *ListFailPointsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1140,7 +1140,7 @@ func (m *ListFailPointsResponse_Entry) Reset()         { *m = ListFailPointsResp
 func (m *ListFailPointsResponse_Entry) String() string { return proto.CompactTextString(m) }
 func (*ListFailPointsResponse_Entry) ProtoMessage()    {}
 func (*ListFailPointsResponse_Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{17, 0}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{17, 0}
 }
 func (m *ListFailPointsResponse_Entry) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1194,7 +1194,7 @@ func (m *GetMetricsRequest) Reset()         { *m = GetMetricsRequest{} }
 func (m *GetMetricsRequest) String() string { return proto.CompactTextString(m) }
 func (*GetMetricsRequest) ProtoMessage()    {}
 func (*GetMetricsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{18}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{18}
 }
 func (m *GetMetricsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1245,7 +1245,7 @@ func (m *GetMetricsResponse) Reset()         { *m = GetMetricsResponse{} }
 func (m *GetMetricsResponse) String() string { return proto.CompactTextString(m) }
 func (*GetMetricsResponse) ProtoMessage()    {}
 func (*GetMetricsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{19}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{19}
 }
 func (m *GetMetricsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1320,7 +1320,7 @@ func (m *RegionConsistencyCheckRequest) Reset()         { *m = RegionConsistency
 func (m *RegionConsistencyCheckRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionConsistencyCheckRequest) ProtoMessage()    {}
 func (*RegionConsistencyCheckRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{20}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{20}
 }
 func (m *RegionConsistencyCheckRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1366,7 +1366,7 @@ func (m *RegionConsistencyCheckResponse) Reset()         { *m = RegionConsistenc
 func (m *RegionConsistencyCheckResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionConsistencyCheckResponse) ProtoMessage()    {}
 func (*RegionConsistencyCheckResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{21}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{21}
 }
 func (m *RegionConsistencyCheckResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1408,7 +1408,7 @@ func (m *ModifyTikvConfigRequest) Reset()         { *m = ModifyTikvConfigRequest
 func (m *ModifyTikvConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*ModifyTikvConfigRequest) ProtoMessage()    {}
 func (*ModifyTikvConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{22}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{22}
 }
 func (m *ModifyTikvConfigRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1468,7 +1468,7 @@ func (m *ModifyTikvConfigResponse) Reset()         { *m = ModifyTikvConfigRespon
 func (m *ModifyTikvConfigResponse) String() string { return proto.CompactTextString(m) }
 func (*ModifyTikvConfigResponse) ProtoMessage()    {}
 func (*ModifyTikvConfigResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{23}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{23}
 }
 func (m *ModifyTikvConfigResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1509,7 +1509,7 @@ func (m *Property) Reset()         { *m = Property{} }
 func (m *Property) String() string { return proto.CompactTextString(m) }
 func (*Property) ProtoMessage()    {}
 func (*Property) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{24}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{24}
 }
 func (m *Property) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1563,7 +1563,7 @@ func (m *GetRegionPropertiesRequest) Reset()         { *m = GetRegionPropertiesR
 func (m *GetRegionPropertiesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRegionPropertiesRequest) ProtoMessage()    {}
 func (*GetRegionPropertiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{25}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{25}
 }
 func (m *GetRegionPropertiesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1610,7 +1610,7 @@ func (m *GetRegionPropertiesResponse) Reset()         { *m = GetRegionProperties
 func (m *GetRegionPropertiesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetRegionPropertiesResponse) ProtoMessage()    {}
 func (*GetRegionPropertiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_debugpb_881d81d7f1aa28b0, []int{26}
+	return fileDescriptor_debugpb_ccc6bf3e01d4730e, []int{26}
 }
 func (m *GetRegionPropertiesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6443,9 +6443,9 @@ var (
 	ErrIntOverflowDebugpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("debugpb.proto", fileDescriptor_debugpb_881d81d7f1aa28b0) }
+func init() { proto.RegisterFile("debugpb.proto", fileDescriptor_debugpb_ccc6bf3e01d4730e) }
 
-var fileDescriptor_debugpb_881d81d7f1aa28b0 = []byte{
+var fileDescriptor_debugpb_ccc6bf3e01d4730e = []byte{
 	// 1422 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x57, 0xcb, 0x6f, 0xdb, 0x46,
 	0x13, 0x17, 0xf5, 0xd6, 0xc8, 0x96, 0xe8, 0x8d, 0x63, 0xcb, 0x34, 0x22, 0xcb, 0xcc, 0xcb, 0xc8,

--- a/pkg/errorpb/errorpb.pb.go
+++ b/pkg/errorpb/errorpb.pb.go
@@ -38,7 +38,7 @@ func (m *NotLeader) Reset()         { *m = NotLeader{} }
 func (m *NotLeader) String() string { return proto.CompactTextString(m) }
 func (*NotLeader) ProtoMessage()    {}
 func (*NotLeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{0}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{0}
 }
 func (m *NotLeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -93,7 +93,7 @@ func (m *StoreNotMatch) Reset()         { *m = StoreNotMatch{} }
 func (m *StoreNotMatch) String() string { return proto.CompactTextString(m) }
 func (*StoreNotMatch) ProtoMessage()    {}
 func (*StoreNotMatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{1}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{1}
 }
 func (m *StoreNotMatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -147,7 +147,7 @@ func (m *RegionNotFound) Reset()         { *m = RegionNotFound{} }
 func (m *RegionNotFound) String() string { return proto.CompactTextString(m) }
 func (*RegionNotFound) ProtoMessage()    {}
 func (*RegionNotFound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{2}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{2}
 }
 func (m *RegionNotFound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -197,7 +197,7 @@ func (m *KeyNotInRegion) Reset()         { *m = KeyNotInRegion{} }
 func (m *KeyNotInRegion) String() string { return proto.CompactTextString(m) }
 func (*KeyNotInRegion) ProtoMessage()    {}
 func (*KeyNotInRegion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{3}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{3}
 }
 func (m *KeyNotInRegion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -265,7 +265,7 @@ func (m *EpochNotMatch) Reset()         { *m = EpochNotMatch{} }
 func (m *EpochNotMatch) String() string { return proto.CompactTextString(m) }
 func (*EpochNotMatch) ProtoMessage()    {}
 func (*EpochNotMatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{4}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{4}
 }
 func (m *EpochNotMatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -313,7 +313,7 @@ func (m *ServerIsBusy) Reset()         { *m = ServerIsBusy{} }
 func (m *ServerIsBusy) String() string { return proto.CompactTextString(m) }
 func (*ServerIsBusy) ProtoMessage()    {}
 func (*ServerIsBusy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{5}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{5}
 }
 func (m *ServerIsBusy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -366,7 +366,7 @@ func (m *StaleCommand) Reset()         { *m = StaleCommand{} }
 func (m *StaleCommand) String() string { return proto.CompactTextString(m) }
 func (*StaleCommand) ProtoMessage()    {}
 func (*StaleCommand) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{6}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{6}
 }
 func (m *StaleCommand) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -407,7 +407,7 @@ func (m *RaftEntryTooLarge) Reset()         { *m = RaftEntryTooLarge{} }
 func (m *RaftEntryTooLarge) String() string { return proto.CompactTextString(m) }
 func (*RaftEntryTooLarge) ProtoMessage()    {}
 func (*RaftEntryTooLarge) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{7}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{7}
 }
 func (m *RaftEntryTooLarge) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -469,7 +469,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_errorpb_cab24447952c2dc7, []int{8}
+	return fileDescriptor_errorpb_7fcd39d68d240207, []int{8}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2317,9 +2317,9 @@ var (
 	ErrIntOverflowErrorpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("errorpb.proto", fileDescriptor_errorpb_cab24447952c2dc7) }
+func init() { proto.RegisterFile("errorpb.proto", fileDescriptor_errorpb_7fcd39d68d240207) }
 
-var fileDescriptor_errorpb_cab24447952c2dc7 = []byte{
+var fileDescriptor_errorpb_7fcd39d68d240207 = []byte{
 	// 651 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x54, 0xcd, 0x6e, 0xd3, 0x4c,
 	0x14, 0xfd, 0xdc, 0x9f, 0x24, 0xbe, 0xb1, 0x9d, 0xd6, 0xea, 0xd7, 0x5a, 0xad, 0x1a, 0x55, 0x16,

--- a/pkg/import_kvpb/import_kvpb.pb.go
+++ b/pkg/import_kvpb/import_kvpb.pb.go
@@ -47,7 +47,7 @@ func (x Mutation_OP) String() string {
 	return proto.EnumName(Mutation_OP_name, int32(x))
 }
 func (Mutation_OP) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{5, 0}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{5, 0}
 }
 
 type SwitchModeRequest struct {
@@ -62,7 +62,7 @@ func (m *SwitchModeRequest) Reset()         { *m = SwitchModeRequest{} }
 func (m *SwitchModeRequest) String() string { return proto.CompactTextString(m) }
 func (*SwitchModeRequest) ProtoMessage()    {}
 func (*SwitchModeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{0}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{0}
 }
 func (m *SwitchModeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -115,7 +115,7 @@ func (m *SwitchModeResponse) Reset()         { *m = SwitchModeResponse{} }
 func (m *SwitchModeResponse) String() string { return proto.CompactTextString(m) }
 func (*SwitchModeResponse) ProtoMessage()    {}
 func (*SwitchModeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{1}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{1}
 }
 func (m *SwitchModeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -155,7 +155,7 @@ func (m *OpenEngineRequest) Reset()         { *m = OpenEngineRequest{} }
 func (m *OpenEngineRequest) String() string { return proto.CompactTextString(m) }
 func (*OpenEngineRequest) ProtoMessage()    {}
 func (*OpenEngineRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{2}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{2}
 }
 func (m *OpenEngineRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -201,7 +201,7 @@ func (m *OpenEngineResponse) Reset()         { *m = OpenEngineResponse{} }
 func (m *OpenEngineResponse) String() string { return proto.CompactTextString(m) }
 func (*OpenEngineResponse) ProtoMessage()    {}
 func (*OpenEngineResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{3}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{3}
 }
 func (m *OpenEngineResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -241,7 +241,7 @@ func (m *WriteHead) Reset()         { *m = WriteHead{} }
 func (m *WriteHead) String() string { return proto.CompactTextString(m) }
 func (*WriteHead) ProtoMessage()    {}
 func (*WriteHead) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{4}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{4}
 }
 func (m *WriteHead) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -290,7 +290,7 @@ func (m *Mutation) Reset()         { *m = Mutation{} }
 func (m *Mutation) String() string { return proto.CompactTextString(m) }
 func (*Mutation) ProtoMessage()    {}
 func (*Mutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{5}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{5}
 }
 func (m *Mutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -352,7 +352,7 @@ func (m *WriteBatch) Reset()         { *m = WriteBatch{} }
 func (m *WriteBatch) String() string { return proto.CompactTextString(m) }
 func (*WriteBatch) ProtoMessage()    {}
 func (*WriteBatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{6}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{6}
 }
 func (m *WriteBatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -409,7 +409,7 @@ func (m *WriteEngineRequest) Reset()         { *m = WriteEngineRequest{} }
 func (m *WriteEngineRequest) String() string { return proto.CompactTextString(m) }
 func (*WriteEngineRequest) ProtoMessage()    {}
 func (*WriteEngineRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{7}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{7}
 }
 func (m *WriteEngineRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -560,7 +560,7 @@ func (m *WriteEngineResponse) Reset()         { *m = WriteEngineResponse{} }
 func (m *WriteEngineResponse) String() string { return proto.CompactTextString(m) }
 func (*WriteEngineResponse) ProtoMessage()    {}
 func (*WriteEngineResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{8}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{8}
 }
 func (m *WriteEngineResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -607,7 +607,7 @@ func (m *CloseEngineRequest) Reset()         { *m = CloseEngineRequest{} }
 func (m *CloseEngineRequest) String() string { return proto.CompactTextString(m) }
 func (*CloseEngineRequest) ProtoMessage()    {}
 func (*CloseEngineRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{9}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{9}
 }
 func (m *CloseEngineRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -654,7 +654,7 @@ func (m *CloseEngineResponse) Reset()         { *m = CloseEngineResponse{} }
 func (m *CloseEngineResponse) String() string { return proto.CompactTextString(m) }
 func (*CloseEngineResponse) ProtoMessage()    {}
 func (*CloseEngineResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{10}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{10}
 }
 func (m *CloseEngineResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -702,7 +702,7 @@ func (m *ImportEngineRequest) Reset()         { *m = ImportEngineRequest{} }
 func (m *ImportEngineRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportEngineRequest) ProtoMessage()    {}
 func (*ImportEngineRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{11}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{11}
 }
 func (m *ImportEngineRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -755,7 +755,7 @@ func (m *ImportEngineResponse) Reset()         { *m = ImportEngineResponse{} }
 func (m *ImportEngineResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportEngineResponse) ProtoMessage()    {}
 func (*ImportEngineResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{12}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{12}
 }
 func (m *ImportEngineResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -795,7 +795,7 @@ func (m *CleanupEngineRequest) Reset()         { *m = CleanupEngineRequest{} }
 func (m *CleanupEngineRequest) String() string { return proto.CompactTextString(m) }
 func (*CleanupEngineRequest) ProtoMessage()    {}
 func (*CleanupEngineRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{13}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{13}
 }
 func (m *CleanupEngineRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -841,7 +841,7 @@ func (m *CleanupEngineResponse) Reset()         { *m = CleanupEngineResponse{} }
 func (m *CleanupEngineResponse) String() string { return proto.CompactTextString(m) }
 func (*CleanupEngineResponse) ProtoMessage()    {}
 func (*CleanupEngineResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{14}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{14}
 }
 func (m *CleanupEngineResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -882,7 +882,7 @@ func (m *CompactClusterRequest) Reset()         { *m = CompactClusterRequest{} }
 func (m *CompactClusterRequest) String() string { return proto.CompactTextString(m) }
 func (*CompactClusterRequest) ProtoMessage()    {}
 func (*CompactClusterRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{15}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{15}
 }
 func (m *CompactClusterRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -935,7 +935,7 @@ func (m *CompactClusterResponse) Reset()         { *m = CompactClusterResponse{}
 func (m *CompactClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*CompactClusterResponse) ProtoMessage()    {}
 func (*CompactClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{16}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{16}
 }
 func (m *CompactClusterResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -979,7 +979,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{17}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{17}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1026,7 +1026,7 @@ func (m *Error_EngineNotFound) Reset()         { *m = Error_EngineNotFound{} }
 func (m *Error_EngineNotFound) String() string { return proto.CompactTextString(m) }
 func (*Error_EngineNotFound) ProtoMessage()    {}
 func (*Error_EngineNotFound) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_kvpb_ae8ae036691db3a8, []int{17, 0}
+	return fileDescriptor_import_kvpb_da008e48923ad467, []int{17, 0}
 }
 func (m *Error_EngineNotFound) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3973,9 +3973,9 @@ var (
 	ErrIntOverflowImportKvpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("import_kvpb.proto", fileDescriptor_import_kvpb_ae8ae036691db3a8) }
+func init() { proto.RegisterFile("import_kvpb.proto", fileDescriptor_import_kvpb_da008e48923ad467) }
 
-var fileDescriptor_import_kvpb_ae8ae036691db3a8 = []byte{
+var fileDescriptor_import_kvpb_da008e48923ad467 = []byte{
 	// 710 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0x6d, 0x6f, 0xd2, 0x50,
 	0x14, 0xa6, 0xbc, 0x0c, 0x38, 0x6c, 0xc8, 0xce, 0xd8, 0x46, 0xd0, 0x00, 0xab, 0x46, 0x89, 0x31,

--- a/pkg/import_sstpb/import_sstpb.pb.go
+++ b/pkg/import_sstpb/import_sstpb.pb.go
@@ -54,7 +54,7 @@ func (x SwitchMode) String() string {
 	return proto.EnumName(SwitchMode_name, int32(x))
 }
 func (SwitchMode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{0}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{0}
 }
 
 type SwitchModeRequest struct {
@@ -68,7 +68,7 @@ func (m *SwitchModeRequest) Reset()         { *m = SwitchModeRequest{} }
 func (m *SwitchModeRequest) String() string { return proto.CompactTextString(m) }
 func (*SwitchModeRequest) ProtoMessage()    {}
 func (*SwitchModeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{0}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{0}
 }
 func (m *SwitchModeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -114,7 +114,7 @@ func (m *SwitchModeResponse) Reset()         { *m = SwitchModeResponse{} }
 func (m *SwitchModeResponse) String() string { return proto.CompactTextString(m) }
 func (*SwitchModeResponse) ProtoMessage()    {}
 func (*SwitchModeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{1}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{1}
 }
 func (m *SwitchModeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -155,7 +155,7 @@ func (m *Range) Reset()         { *m = Range{} }
 func (m *Range) String() string { return proto.CompactTextString(m) }
 func (*Range) ProtoMessage()    {}
 func (*Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{2}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{2}
 }
 func (m *Range) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -215,7 +215,7 @@ func (m *SSTMeta) Reset()         { *m = SSTMeta{} }
 func (m *SSTMeta) String() string { return proto.CompactTextString(m) }
 func (*SSTMeta) ProtoMessage()    {}
 func (*SSTMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{3}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{3}
 }
 func (m *SSTMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -307,7 +307,7 @@ func (m *UploadRequest) Reset()         { *m = UploadRequest{} }
 func (m *UploadRequest) String() string { return proto.CompactTextString(m) }
 func (*UploadRequest) ProtoMessage()    {}
 func (*UploadRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{4}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{4}
 }
 func (m *UploadRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -453,7 +453,7 @@ func (m *UploadResponse) Reset()         { *m = UploadResponse{} }
 func (m *UploadResponse) String() string { return proto.CompactTextString(m) }
 func (*UploadResponse) ProtoMessage()    {}
 func (*UploadResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{5}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{5}
 }
 func (m *UploadResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -494,7 +494,7 @@ func (m *IngestRequest) Reset()         { *m = IngestRequest{} }
 func (m *IngestRequest) String() string { return proto.CompactTextString(m) }
 func (*IngestRequest) ProtoMessage()    {}
 func (*IngestRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{6}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{6}
 }
 func (m *IngestRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -548,7 +548,7 @@ func (m *IngestResponse) Reset()         { *m = IngestResponse{} }
 func (m *IngestResponse) String() string { return proto.CompactTextString(m) }
 func (*IngestResponse) ProtoMessage()    {}
 func (*IngestResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{7}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{7}
 }
 func (m *IngestResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -599,7 +599,7 @@ func (m *CompactRequest) Reset()         { *m = CompactRequest{} }
 func (m *CompactRequest) String() string { return proto.CompactTextString(m) }
 func (*CompactRequest) ProtoMessage()    {}
 func (*CompactRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{8}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{8}
 }
 func (m *CompactRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -652,7 +652,7 @@ func (m *CompactResponse) Reset()         { *m = CompactResponse{} }
 func (m *CompactResponse) String() string { return proto.CompactTextString(m) }
 func (*CompactResponse) ProtoMessage()    {}
 func (*CompactResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_import_sstpb_c6f19719a4d56637, []int{9}
+	return fileDescriptor_import_sstpb_dd1f6bc4d1bd9772, []int{9}
 }
 func (m *CompactResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2539,9 +2539,9 @@ var (
 	ErrIntOverflowImportSstpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("import_sstpb.proto", fileDescriptor_import_sstpb_c6f19719a4d56637) }
+func init() { proto.RegisterFile("import_sstpb.proto", fileDescriptor_import_sstpb_dd1f6bc4d1bd9772) }
 
-var fileDescriptor_import_sstpb_c6f19719a4d56637 = []byte{
+var fileDescriptor_import_sstpb_dd1f6bc4d1bd9772 = []byte{
 	// 628 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0xcd, 0x6e, 0xd3, 0x40,
 	0x10, 0xce, 0xb6, 0xb1, 0xd3, 0x4e, 0x7e, 0x9a, 0x2e, 0x01, 0xac, 0x14, 0x42, 0xb0, 0x2a, 0x08,

--- a/pkg/kvrpcpb/kvrpcpb.pb.go
+++ b/pkg/kvrpcpb/kvrpcpb.pb.go
@@ -51,7 +51,7 @@ func (x CommandPri) String() string {
 	return proto.EnumName(CommandPri_name, int32(x))
 }
 func (CommandPri) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{0}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{0}
 }
 
 type IsolationLevel int32
@@ -74,7 +74,7 @@ func (x IsolationLevel) String() string {
 	return proto.EnumName(IsolationLevel_name, int32(x))
 }
 func (IsolationLevel) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{1}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{1}
 }
 
 type Op int32
@@ -107,7 +107,7 @@ func (x Op) String() string {
 	return proto.EnumName(Op_name, int32(x))
 }
 func (Op) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{2}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{2}
 }
 
 type Assertion int32
@@ -133,7 +133,7 @@ func (x Assertion) String() string {
 	return proto.EnumName(Assertion_name, int32(x))
 }
 func (Assertion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{3}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{3}
 }
 
 type LockInfo struct {
@@ -150,7 +150,7 @@ func (m *LockInfo) Reset()         { *m = LockInfo{} }
 func (m *LockInfo) String() string { return proto.CompactTextString(m) }
 func (*LockInfo) ProtoMessage()    {}
 func (*LockInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{0}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{0}
 }
 func (m *LockInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -218,7 +218,7 @@ func (m *AlreadyExist) Reset()         { *m = AlreadyExist{} }
 func (m *AlreadyExist) String() string { return proto.CompactTextString(m) }
 func (*AlreadyExist) ProtoMessage()    {}
 func (*AlreadyExist) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{1}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{1}
 }
 func (m *AlreadyExist) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -269,7 +269,7 @@ func (m *KeyError) Reset()         { *m = KeyError{} }
 func (m *KeyError) String() string { return proto.CompactTextString(m) }
 func (*KeyError) ProtoMessage()    {}
 func (*KeyError) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{2}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{2}
 }
 func (m *KeyError) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -347,7 +347,7 @@ func (m *WriteConflict) Reset()         { *m = WriteConflict{} }
 func (m *WriteConflict) String() string { return proto.CompactTextString(m) }
 func (*WriteConflict) ProtoMessage()    {}
 func (*WriteConflict) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{3}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{3}
 }
 func (m *WriteConflict) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -424,7 +424,7 @@ func (m *Context) Reset()         { *m = Context{} }
 func (m *Context) String() string { return proto.CompactTextString(m) }
 func (*Context) ProtoMessage()    {}
 func (*Context) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{4}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{4}
 }
 func (m *Context) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -535,7 +535,7 @@ func (m *HandleTime) Reset()         { *m = HandleTime{} }
 func (m *HandleTime) String() string { return proto.CompactTextString(m) }
 func (*HandleTime) ProtoMessage()    {}
 func (*HandleTime) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{5}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{5}
 }
 func (m *HandleTime) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -590,7 +590,7 @@ func (m *ScanInfo) Reset()         { *m = ScanInfo{} }
 func (m *ScanInfo) String() string { return proto.CompactTextString(m) }
 func (*ScanInfo) ProtoMessage()    {}
 func (*ScanInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{6}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{6}
 }
 func (m *ScanInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -646,7 +646,7 @@ func (m *ScanDetail) Reset()         { *m = ScanDetail{} }
 func (m *ScanDetail) String() string { return proto.CompactTextString(m) }
 func (*ScanDetail) ProtoMessage()    {}
 func (*ScanDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{7}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{7}
 }
 func (m *ScanDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -708,7 +708,7 @@ func (m *ExecDetails) Reset()         { *m = ExecDetails{} }
 func (m *ExecDetails) String() string { return proto.CompactTextString(m) }
 func (*ExecDetails) ProtoMessage()    {}
 func (*ExecDetails) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{8}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{8}
 }
 func (m *ExecDetails) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -764,7 +764,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{9}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{9}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -827,7 +827,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{10}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{10}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -896,7 +896,7 @@ func (m *ScanRequest) Reset()         { *m = ScanRequest{} }
 func (m *ScanRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanRequest) ProtoMessage()    {}
 func (*ScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{11}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{11}
 }
 func (m *ScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -987,7 +987,7 @@ func (m *KvPair) Reset()         { *m = KvPair{} }
 func (m *KvPair) String() string { return proto.CompactTextString(m) }
 func (*KvPair) ProtoMessage()    {}
 func (*KvPair) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{12}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{12}
 }
 func (m *KvPair) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1049,7 +1049,7 @@ func (m *ScanResponse) Reset()         { *m = ScanResponse{} }
 func (m *ScanResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanResponse) ProtoMessage()    {}
 func (*ScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{13}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{13}
 }
 func (m *ScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1106,7 +1106,7 @@ func (m *Mutation) Reset()         { *m = Mutation{} }
 func (m *Mutation) String() string { return proto.CompactTextString(m) }
 func (*Mutation) ProtoMessage()    {}
 func (*Mutation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{14}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{14}
 }
 func (m *Mutation) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1180,7 +1180,7 @@ func (m *PrewriteRequest) Reset()         { *m = PrewriteRequest{} }
 func (m *PrewriteRequest) String() string { return proto.CompactTextString(m) }
 func (*PrewriteRequest) ProtoMessage()    {}
 func (*PrewriteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{15}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{15}
 }
 func (m *PrewriteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1263,7 +1263,7 @@ func (m *PrewriteResponse) Reset()         { *m = PrewriteResponse{} }
 func (m *PrewriteResponse) String() string { return proto.CompactTextString(m) }
 func (*PrewriteResponse) ProtoMessage()    {}
 func (*PrewriteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{16}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{16}
 }
 func (m *PrewriteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1320,7 +1320,7 @@ func (m *CommitRequest) Reset()         { *m = CommitRequest{} }
 func (m *CommitRequest) String() string { return proto.CompactTextString(m) }
 func (*CommitRequest) ProtoMessage()    {}
 func (*CommitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{17}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{17}
 }
 func (m *CommitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1389,7 +1389,7 @@ func (m *CommitResponse) Reset()         { *m = CommitResponse{} }
 func (m *CommitResponse) String() string { return proto.CompactTextString(m) }
 func (*CommitResponse) ProtoMessage()    {}
 func (*CommitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{18}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{18}
 }
 func (m *CommitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1444,7 +1444,7 @@ func (m *ImportRequest) Reset()         { *m = ImportRequest{} }
 func (m *ImportRequest) String() string { return proto.CompactTextString(m) }
 func (*ImportRequest) ProtoMessage()    {}
 func (*ImportRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{19}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{19}
 }
 func (m *ImportRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1499,7 +1499,7 @@ func (m *ImportResponse) Reset()         { *m = ImportResponse{} }
 func (m *ImportResponse) String() string { return proto.CompactTextString(m) }
 func (*ImportResponse) ProtoMessage()    {}
 func (*ImportResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{20}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{20}
 }
 func (m *ImportResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1555,7 +1555,7 @@ func (m *BatchRollbackRequest) Reset()         { *m = BatchRollbackRequest{} }
 func (m *BatchRollbackRequest) String() string { return proto.CompactTextString(m) }
 func (*BatchRollbackRequest) ProtoMessage()    {}
 func (*BatchRollbackRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{21}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{21}
 }
 func (m *BatchRollbackRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1617,7 +1617,7 @@ func (m *BatchRollbackResponse) Reset()         { *m = BatchRollbackResponse{} }
 func (m *BatchRollbackResponse) String() string { return proto.CompactTextString(m) }
 func (*BatchRollbackResponse) ProtoMessage()    {}
 func (*BatchRollbackResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{22}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{22}
 }
 func (m *BatchRollbackResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1673,7 +1673,7 @@ func (m *CleanupRequest) Reset()         { *m = CleanupRequest{} }
 func (m *CleanupRequest) String() string { return proto.CompactTextString(m) }
 func (*CleanupRequest) ProtoMessage()    {}
 func (*CleanupRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{23}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{23}
 }
 func (m *CleanupRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1736,7 +1736,7 @@ func (m *CleanupResponse) Reset()         { *m = CleanupResponse{} }
 func (m *CleanupResponse) String() string { return proto.CompactTextString(m) }
 func (*CleanupResponse) ProtoMessage()    {}
 func (*CleanupResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{24}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{24}
 }
 func (m *CleanupResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1799,7 +1799,7 @@ func (m *BatchGetRequest) Reset()         { *m = BatchGetRequest{} }
 func (m *BatchGetRequest) String() string { return proto.CompactTextString(m) }
 func (*BatchGetRequest) ProtoMessage()    {}
 func (*BatchGetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{25}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{25}
 }
 func (m *BatchGetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1861,7 +1861,7 @@ func (m *BatchGetResponse) Reset()         { *m = BatchGetResponse{} }
 func (m *BatchGetResponse) String() string { return proto.CompactTextString(m) }
 func (*BatchGetResponse) ProtoMessage()    {}
 func (*BatchGetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{26}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{26}
 }
 func (m *BatchGetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1918,7 +1918,7 @@ func (m *ScanLockRequest) Reset()         { *m = ScanLockRequest{} }
 func (m *ScanLockRequest) String() string { return proto.CompactTextString(m) }
 func (*ScanLockRequest) ProtoMessage()    {}
 func (*ScanLockRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{27}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{27}
 }
 func (m *ScanLockRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1988,7 +1988,7 @@ func (m *ScanLockResponse) Reset()         { *m = ScanLockResponse{} }
 func (m *ScanLockResponse) String() string { return proto.CompactTextString(m) }
 func (*ScanLockResponse) ProtoMessage()    {}
 func (*ScanLockResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{28}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{28}
 }
 func (m *ScanLockResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2050,7 +2050,7 @@ func (m *TxnInfo) Reset()         { *m = TxnInfo{} }
 func (m *TxnInfo) String() string { return proto.CompactTextString(m) }
 func (*TxnInfo) ProtoMessage()    {}
 func (*TxnInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{29}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{29}
 }
 func (m *TxnInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2108,7 +2108,7 @@ func (m *ResolveLockRequest) Reset()         { *m = ResolveLockRequest{} }
 func (m *ResolveLockRequest) String() string { return proto.CompactTextString(m) }
 func (*ResolveLockRequest) ProtoMessage()    {}
 func (*ResolveLockRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{30}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{30}
 }
 func (m *ResolveLockRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2177,7 +2177,7 @@ func (m *ResolveLockResponse) Reset()         { *m = ResolveLockResponse{} }
 func (m *ResolveLockResponse) String() string { return proto.CompactTextString(m) }
 func (*ResolveLockResponse) ProtoMessage()    {}
 func (*ResolveLockResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{31}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{31}
 }
 func (m *ResolveLockResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2232,7 +2232,7 @@ func (m *GCRequest) Reset()         { *m = GCRequest{} }
 func (m *GCRequest) String() string { return proto.CompactTextString(m) }
 func (*GCRequest) ProtoMessage()    {}
 func (*GCRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{32}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{32}
 }
 func (m *GCRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2287,7 +2287,7 @@ func (m *GCResponse) Reset()         { *m = GCResponse{} }
 func (m *GCResponse) String() string { return proto.CompactTextString(m) }
 func (*GCResponse) ProtoMessage()    {}
 func (*GCResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{33}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{33}
 }
 func (m *GCResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2343,7 +2343,7 @@ func (m *RawGetRequest) Reset()         { *m = RawGetRequest{} }
 func (m *RawGetRequest) String() string { return proto.CompactTextString(m) }
 func (*RawGetRequest) ProtoMessage()    {}
 func (*RawGetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{34}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{34}
 }
 func (m *RawGetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2406,7 +2406,7 @@ func (m *RawGetResponse) Reset()         { *m = RawGetResponse{} }
 func (m *RawGetResponse) String() string { return proto.CompactTextString(m) }
 func (*RawGetResponse) ProtoMessage()    {}
 func (*RawGetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{35}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{35}
 }
 func (m *RawGetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2470,7 +2470,7 @@ func (m *RawPutRequest) Reset()         { *m = RawPutRequest{} }
 func (m *RawPutRequest) String() string { return proto.CompactTextString(m) }
 func (*RawPutRequest) ProtoMessage()    {}
 func (*RawPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{36}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{36}
 }
 func (m *RawPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2539,7 +2539,7 @@ func (m *RawPutResponse) Reset()         { *m = RawPutResponse{} }
 func (m *RawPutResponse) String() string { return proto.CompactTextString(m) }
 func (*RawPutResponse) ProtoMessage()    {}
 func (*RawPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{37}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{37}
 }
 func (m *RawPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2595,7 +2595,7 @@ func (m *RawBatchPutRequest) Reset()         { *m = RawBatchPutRequest{} }
 func (m *RawBatchPutRequest) String() string { return proto.CompactTextString(m) }
 func (*RawBatchPutRequest) ProtoMessage()    {}
 func (*RawBatchPutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{38}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{38}
 }
 func (m *RawBatchPutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2657,7 +2657,7 @@ func (m *RawBatchPutResponse) Reset()         { *m = RawBatchPutResponse{} }
 func (m *RawBatchPutResponse) String() string { return proto.CompactTextString(m) }
 func (*RawBatchPutResponse) ProtoMessage()    {}
 func (*RawBatchPutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{39}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{39}
 }
 func (m *RawBatchPutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2713,7 +2713,7 @@ func (m *RawBatchGetRequest) Reset()         { *m = RawBatchGetRequest{} }
 func (m *RawBatchGetRequest) String() string { return proto.CompactTextString(m) }
 func (*RawBatchGetRequest) ProtoMessage()    {}
 func (*RawBatchGetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{40}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{40}
 }
 func (m *RawBatchGetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2775,7 +2775,7 @@ func (m *RawBatchGetResponse) Reset()         { *m = RawBatchGetResponse{} }
 func (m *RawBatchGetResponse) String() string { return proto.CompactTextString(m) }
 func (*RawBatchGetResponse) ProtoMessage()    {}
 func (*RawBatchGetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{41}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{41}
 }
 func (m *RawBatchGetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2831,7 +2831,7 @@ func (m *RawDeleteRequest) Reset()         { *m = RawDeleteRequest{} }
 func (m *RawDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*RawDeleteRequest) ProtoMessage()    {}
 func (*RawDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{42}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{42}
 }
 func (m *RawDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2893,7 +2893,7 @@ func (m *RawDeleteResponse) Reset()         { *m = RawDeleteResponse{} }
 func (m *RawDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*RawDeleteResponse) ProtoMessage()    {}
 func (*RawDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{43}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{43}
 }
 func (m *RawDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2949,7 +2949,7 @@ func (m *RawBatchDeleteRequest) Reset()         { *m = RawBatchDeleteRequest{} }
 func (m *RawBatchDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*RawBatchDeleteRequest) ProtoMessage()    {}
 func (*RawBatchDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{44}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{44}
 }
 func (m *RawBatchDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3011,7 +3011,7 @@ func (m *RawBatchDeleteResponse) Reset()         { *m = RawBatchDeleteResponse{}
 func (m *RawBatchDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*RawBatchDeleteResponse) ProtoMessage()    {}
 func (*RawBatchDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{45}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{45}
 }
 func (m *RawBatchDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3067,7 +3067,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{46}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{46}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3129,7 +3129,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{47}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{47}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3186,7 +3186,7 @@ func (m *RawDeleteRangeRequest) Reset()         { *m = RawDeleteRangeRequest{} }
 func (m *RawDeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*RawDeleteRangeRequest) ProtoMessage()    {}
 func (*RawDeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{48}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{48}
 }
 func (m *RawDeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3255,7 +3255,7 @@ func (m *RawDeleteRangeResponse) Reset()         { *m = RawDeleteRangeResponse{}
 func (m *RawDeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*RawDeleteRangeResponse) ProtoMessage()    {}
 func (*RawDeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{49}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{49}
 }
 func (m *RawDeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3317,7 +3317,7 @@ func (m *RawScanRequest) Reset()         { *m = RawScanRequest{} }
 func (m *RawScanRequest) String() string { return proto.CompactTextString(m) }
 func (*RawScanRequest) ProtoMessage()    {}
 func (*RawScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{50}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{50}
 }
 func (m *RawScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3407,7 +3407,7 @@ func (m *RawScanResponse) Reset()         { *m = RawScanResponse{} }
 func (m *RawScanResponse) String() string { return proto.CompactTextString(m) }
 func (*RawScanResponse) ProtoMessage()    {}
 func (*RawScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{51}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{51}
 }
 func (m *RawScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3462,7 +3462,7 @@ func (m *KeyRange) Reset()         { *m = KeyRange{} }
 func (m *KeyRange) String() string { return proto.CompactTextString(m) }
 func (*KeyRange) ProtoMessage()    {}
 func (*KeyRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{52}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{52}
 }
 func (m *KeyRange) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3521,7 +3521,7 @@ func (m *RawBatchScanRequest) Reset()         { *m = RawBatchScanRequest{} }
 func (m *RawBatchScanRequest) String() string { return proto.CompactTextString(m) }
 func (*RawBatchScanRequest) ProtoMessage()    {}
 func (*RawBatchScanRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{53}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{53}
 }
 func (m *RawBatchScanRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3604,7 +3604,7 @@ func (m *RawBatchScanResponse) Reset()         { *m = RawBatchScanResponse{} }
 func (m *RawBatchScanResponse) String() string { return proto.CompactTextString(m) }
 func (*RawBatchScanResponse) ProtoMessage()    {}
 func (*RawBatchScanResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{54}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{54}
 }
 func (m *RawBatchScanResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3661,7 +3661,7 @@ func (m *MvccWrite) Reset()         { *m = MvccWrite{} }
 func (m *MvccWrite) String() string { return proto.CompactTextString(m) }
 func (*MvccWrite) ProtoMessage()    {}
 func (*MvccWrite) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{55}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{55}
 }
 func (m *MvccWrite) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3730,7 +3730,7 @@ func (m *MvccValue) Reset()         { *m = MvccValue{} }
 func (m *MvccValue) String() string { return proto.CompactTextString(m) }
 func (*MvccValue) ProtoMessage()    {}
 func (*MvccValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{56}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{56}
 }
 func (m *MvccValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3787,7 +3787,7 @@ func (m *MvccLock) Reset()         { *m = MvccLock{} }
 func (m *MvccLock) String() string { return proto.CompactTextString(m) }
 func (*MvccLock) ProtoMessage()    {}
 func (*MvccLock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{57}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{57}
 }
 func (m *MvccLock) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3857,7 +3857,7 @@ func (m *MvccInfo) Reset()         { *m = MvccInfo{} }
 func (m *MvccInfo) String() string { return proto.CompactTextString(m) }
 func (*MvccInfo) ProtoMessage()    {}
 func (*MvccInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{58}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{58}
 }
 func (m *MvccInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3919,7 +3919,7 @@ func (m *MvccGetByKeyRequest) Reset()         { *m = MvccGetByKeyRequest{} }
 func (m *MvccGetByKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*MvccGetByKeyRequest) ProtoMessage()    {}
 func (*MvccGetByKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{59}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{59}
 }
 func (m *MvccGetByKeyRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3975,7 +3975,7 @@ func (m *MvccGetByKeyResponse) Reset()         { *m = MvccGetByKeyResponse{} }
 func (m *MvccGetByKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*MvccGetByKeyResponse) ProtoMessage()    {}
 func (*MvccGetByKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{60}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{60}
 }
 func (m *MvccGetByKeyResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4037,7 +4037,7 @@ func (m *MvccGetByStartTsRequest) Reset()         { *m = MvccGetByStartTsRequest
 func (m *MvccGetByStartTsRequest) String() string { return proto.CompactTextString(m) }
 func (*MvccGetByStartTsRequest) ProtoMessage()    {}
 func (*MvccGetByStartTsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{61}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{61}
 }
 func (m *MvccGetByStartTsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4094,7 +4094,7 @@ func (m *MvccGetByStartTsResponse) Reset()         { *m = MvccGetByStartTsRespon
 func (m *MvccGetByStartTsResponse) String() string { return proto.CompactTextString(m) }
 func (*MvccGetByStartTsResponse) ProtoMessage()    {}
 func (*MvccGetByStartTsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{62}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{62}
 }
 func (m *MvccGetByStartTsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4163,7 +4163,7 @@ func (m *SplitRegionRequest) Reset()         { *m = SplitRegionRequest{} }
 func (m *SplitRegionRequest) String() string { return proto.CompactTextString(m) }
 func (*SplitRegionRequest) ProtoMessage()    {}
 func (*SplitRegionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{63}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{63}
 }
 func (m *SplitRegionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4219,7 +4219,7 @@ func (m *SplitRegionResponse) Reset()         { *m = SplitRegionResponse{} }
 func (m *SplitRegionResponse) String() string { return proto.CompactTextString(m) }
 func (*SplitRegionResponse) ProtoMessage()    {}
 func (*SplitRegionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{64}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{64}
 }
 func (m *SplitRegionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4282,7 +4282,7 @@ func (m *UnsafeDestroyRangeRequest) Reset()         { *m = UnsafeDestroyRangeReq
 func (m *UnsafeDestroyRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDestroyRangeRequest) ProtoMessage()    {}
 func (*UnsafeDestroyRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{65}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{65}
 }
 func (m *UnsafeDestroyRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4344,7 +4344,7 @@ func (m *UnsafeDestroyRangeResponse) Reset()         { *m = UnsafeDestroyRangeRe
 func (m *UnsafeDestroyRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*UnsafeDestroyRangeResponse) ProtoMessage()    {}
 func (*UnsafeDestroyRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_kvrpcpb_3b842ef971632f78, []int{66}
+	return fileDescriptor_kvrpcpb_1d1e61477e631345, []int{66}
 }
 func (m *UnsafeDestroyRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -18212,9 +18212,9 @@ var (
 	ErrIntOverflowKvrpcpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("kvrpcpb.proto", fileDescriptor_kvrpcpb_3b842ef971632f78) }
+func init() { proto.RegisterFile("kvrpcpb.proto", fileDescriptor_kvrpcpb_1d1e61477e631345) }
 
-var fileDescriptor_kvrpcpb_3b842ef971632f78 = []byte{
+var fileDescriptor_kvrpcpb_1d1e61477e631345 = []byte{
 	// 2155 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x5a, 0x5f, 0x6f, 0x1b, 0xc7,
 	0x11, 0xf7, 0x1d, 0x8f, 0xe4, 0x71, 0xf8, 0x47, 0x97, 0x95, 0x1c, 0x33, 0x76, 0x63, 0x2b, 0xd7,

--- a/pkg/metapb/metapb.pb.go
+++ b/pkg/metapb/metapb.pb.go
@@ -47,7 +47,7 @@ func (x StoreState) String() string {
 	return proto.EnumName(StoreState_name, int32(x))
 }
 func (StoreState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{0}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{0}
 }
 
 type Cluster struct {
@@ -64,7 +64,7 @@ func (m *Cluster) Reset()         { *m = Cluster{} }
 func (m *Cluster) String() string { return proto.CompactTextString(m) }
 func (*Cluster) ProtoMessage()    {}
 func (*Cluster) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{0}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{0}
 }
 func (m *Cluster) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -120,7 +120,7 @@ func (m *StoreLabel) Reset()         { *m = StoreLabel{} }
 func (m *StoreLabel) String() string { return proto.CompactTextString(m) }
 func (*StoreLabel) ProtoMessage()    {}
 func (*StoreLabel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{1}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{1}
 }
 func (m *StoreLabel) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -178,7 +178,7 @@ func (m *Store) Reset()         { *m = Store{} }
 func (m *Store) String() string { return proto.CompactTextString(m) }
 func (*Store) ProtoMessage()    {}
 func (*Store) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{2}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{2}
 }
 func (m *Store) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -256,7 +256,7 @@ func (m *RegionEpoch) Reset()         { *m = RegionEpoch{} }
 func (m *RegionEpoch) String() string { return proto.CompactTextString(m) }
 func (*RegionEpoch) ProtoMessage()    {}
 func (*RegionEpoch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{3}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{3}
 }
 func (m *RegionEpoch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -315,7 +315,7 @@ func (m *Region) Reset()         { *m = Region{} }
 func (m *Region) String() string { return proto.CompactTextString(m) }
 func (*Region) ProtoMessage()    {}
 func (*Region) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{4}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{4}
 }
 func (m *Region) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -392,7 +392,7 @@ func (m *Peer) Reset()         { *m = Peer{} }
 func (m *Peer) String() string { return proto.CompactTextString(m) }
 func (*Peer) ProtoMessage()    {}
 func (*Peer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_metapb_c8d749557dc700ed, []int{5}
+	return fileDescriptor_metapb_974b2ebf5bc867a7, []int{5}
 }
 func (m *Peer) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1723,9 +1723,9 @@ var (
 	ErrIntOverflowMetapb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("metapb.proto", fileDescriptor_metapb_c8d749557dc700ed) }
+func init() { proto.RegisterFile("metapb.proto", fileDescriptor_metapb_974b2ebf5bc867a7) }
 
-var fileDescriptor_metapb_c8d749557dc700ed = []byte{
+var fileDescriptor_metapb_974b2ebf5bc867a7 = []byte{
 	// 485 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x64, 0x52, 0xc1, 0x6e, 0xd3, 0x40,
 	0x10, 0xed, 0x3a, 0xb1, 0x93, 0x4c, 0xdc, 0x60, 0x2d, 0x95, 0x70, 0x8b, 0x88, 0x2c, 0x0b, 0x21,

--- a/pkg/pdpb/pdpb.pb.go
+++ b/pkg/pdpb/pdpb.pb.go
@@ -67,7 +67,7 @@ func (x ErrorType) String() string {
 	return proto.EnumName(ErrorType_name, int32(x))
 }
 func (ErrorType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{0}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{0}
 }
 
 type CheckPolicy int32
@@ -90,7 +90,7 @@ func (x CheckPolicy) String() string {
 	return proto.EnumName(CheckPolicy_name, int32(x))
 }
 func (CheckPolicy) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{1}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{1}
 }
 
 type OperatorStatus int32
@@ -122,7 +122,7 @@ func (x OperatorStatus) String() string {
 	return proto.EnumName(OperatorStatus_name, int32(x))
 }
 func (OperatorStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{2}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{2}
 }
 
 type RequestHeader struct {
@@ -137,7 +137,7 @@ func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
 func (m *RequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RequestHeader) ProtoMessage()    {}
 func (*RequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{0}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{0}
 }
 func (m *RequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -186,7 +186,7 @@ func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
 func (m *ResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*ResponseHeader) ProtoMessage()    {}
 func (*ResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{1}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{1}
 }
 func (m *ResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -241,7 +241,7 @@ func (m *Error) Reset()         { *m = Error{} }
 func (m *Error) String() string { return proto.CompactTextString(m) }
 func (*Error) ProtoMessage()    {}
 func (*Error) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{2}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{2}
 }
 func (m *Error) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -296,7 +296,7 @@ func (m *TsoRequest) Reset()         { *m = TsoRequest{} }
 func (m *TsoRequest) String() string { return proto.CompactTextString(m) }
 func (*TsoRequest) ProtoMessage()    {}
 func (*TsoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{3}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{3}
 }
 func (m *TsoRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -351,7 +351,7 @@ func (m *Timestamp) Reset()         { *m = Timestamp{} }
 func (m *Timestamp) String() string { return proto.CompactTextString(m) }
 func (*Timestamp) ProtoMessage()    {}
 func (*Timestamp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{4}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{4}
 }
 func (m *Timestamp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -407,7 +407,7 @@ func (m *TsoResponse) Reset()         { *m = TsoResponse{} }
 func (m *TsoResponse) String() string { return proto.CompactTextString(m) }
 func (*TsoResponse) ProtoMessage()    {}
 func (*TsoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{5}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{5}
 }
 func (m *TsoResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -470,7 +470,7 @@ func (m *BootstrapRequest) Reset()         { *m = BootstrapRequest{} }
 func (m *BootstrapRequest) String() string { return proto.CompactTextString(m) }
 func (*BootstrapRequest) ProtoMessage()    {}
 func (*BootstrapRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{6}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{6}
 }
 func (m *BootstrapRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -531,7 +531,7 @@ func (m *BootstrapResponse) Reset()         { *m = BootstrapResponse{} }
 func (m *BootstrapResponse) String() string { return proto.CompactTextString(m) }
 func (*BootstrapResponse) ProtoMessage()    {}
 func (*BootstrapResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{7}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{7}
 }
 func (m *BootstrapResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -578,7 +578,7 @@ func (m *IsBootstrappedRequest) Reset()         { *m = IsBootstrappedRequest{} }
 func (m *IsBootstrappedRequest) String() string { return proto.CompactTextString(m) }
 func (*IsBootstrappedRequest) ProtoMessage()    {}
 func (*IsBootstrappedRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{8}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{8}
 }
 func (m *IsBootstrappedRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -626,7 +626,7 @@ func (m *IsBootstrappedResponse) Reset()         { *m = IsBootstrappedResponse{}
 func (m *IsBootstrappedResponse) String() string { return proto.CompactTextString(m) }
 func (*IsBootstrappedResponse) ProtoMessage()    {}
 func (*IsBootstrappedResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{9}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{9}
 }
 func (m *IsBootstrappedResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -680,7 +680,7 @@ func (m *AllocIDRequest) Reset()         { *m = AllocIDRequest{} }
 func (m *AllocIDRequest) String() string { return proto.CompactTextString(m) }
 func (*AllocIDRequest) ProtoMessage()    {}
 func (*AllocIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{10}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{10}
 }
 func (m *AllocIDRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -728,7 +728,7 @@ func (m *AllocIDResponse) Reset()         { *m = AllocIDResponse{} }
 func (m *AllocIDResponse) String() string { return proto.CompactTextString(m) }
 func (*AllocIDResponse) ProtoMessage()    {}
 func (*AllocIDResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{11}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{11}
 }
 func (m *AllocIDResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -783,7 +783,7 @@ func (m *GetStoreRequest) Reset()         { *m = GetStoreRequest{} }
 func (m *GetStoreRequest) String() string { return proto.CompactTextString(m) }
 func (*GetStoreRequest) ProtoMessage()    {}
 func (*GetStoreRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{12}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{12}
 }
 func (m *GetStoreRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -839,7 +839,7 @@ func (m *GetStoreResponse) Reset()         { *m = GetStoreResponse{} }
 func (m *GetStoreResponse) String() string { return proto.CompactTextString(m) }
 func (*GetStoreResponse) ProtoMessage()    {}
 func (*GetStoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{13}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{13}
 }
 func (m *GetStoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -901,7 +901,7 @@ func (m *PutStoreRequest) Reset()         { *m = PutStoreRequest{} }
 func (m *PutStoreRequest) String() string { return proto.CompactTextString(m) }
 func (*PutStoreRequest) ProtoMessage()    {}
 func (*PutStoreRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{14}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{14}
 }
 func (m *PutStoreRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -955,7 +955,7 @@ func (m *PutStoreResponse) Reset()         { *m = PutStoreResponse{} }
 func (m *PutStoreResponse) String() string { return proto.CompactTextString(m) }
 func (*PutStoreResponse) ProtoMessage()    {}
 func (*PutStoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{15}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{15}
 }
 func (m *PutStoreResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1004,7 +1004,7 @@ func (m *GetAllStoresRequest) Reset()         { *m = GetAllStoresRequest{} }
 func (m *GetAllStoresRequest) String() string { return proto.CompactTextString(m) }
 func (*GetAllStoresRequest) ProtoMessage()    {}
 func (*GetAllStoresRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{16}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{16}
 }
 func (m *GetAllStoresRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1059,7 +1059,7 @@ func (m *GetAllStoresResponse) Reset()         { *m = GetAllStoresResponse{} }
 func (m *GetAllStoresResponse) String() string { return proto.CompactTextString(m) }
 func (*GetAllStoresResponse) ProtoMessage()    {}
 func (*GetAllStoresResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{17}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{17}
 }
 func (m *GetAllStoresResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1114,7 +1114,7 @@ func (m *GetRegionRequest) Reset()         { *m = GetRegionRequest{} }
 func (m *GetRegionRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRegionRequest) ProtoMessage()    {}
 func (*GetRegionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{18}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{18}
 }
 func (m *GetRegionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1170,7 +1170,7 @@ func (m *GetRegionResponse) Reset()         { *m = GetRegionResponse{} }
 func (m *GetRegionResponse) String() string { return proto.CompactTextString(m) }
 func (*GetRegionResponse) ProtoMessage()    {}
 func (*GetRegionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{19}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{19}
 }
 func (m *GetRegionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1232,7 +1232,7 @@ func (m *GetRegionByIDRequest) Reset()         { *m = GetRegionByIDRequest{} }
 func (m *GetRegionByIDRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRegionByIDRequest) ProtoMessage()    {}
 func (*GetRegionByIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{20}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{20}
 }
 func (m *GetRegionByIDRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1286,7 +1286,7 @@ func (m *GetClusterConfigRequest) Reset()         { *m = GetClusterConfigRequest
 func (m *GetClusterConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*GetClusterConfigRequest) ProtoMessage()    {}
 func (*GetClusterConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{21}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{21}
 }
 func (m *GetClusterConfigRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1334,7 +1334,7 @@ func (m *GetClusterConfigResponse) Reset()         { *m = GetClusterConfigRespon
 func (m *GetClusterConfigResponse) String() string { return proto.CompactTextString(m) }
 func (*GetClusterConfigResponse) ProtoMessage()    {}
 func (*GetClusterConfigResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{22}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{22}
 }
 func (m *GetClusterConfigResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1389,7 +1389,7 @@ func (m *PutClusterConfigRequest) Reset()         { *m = PutClusterConfigRequest
 func (m *PutClusterConfigRequest) String() string { return proto.CompactTextString(m) }
 func (*PutClusterConfigRequest) ProtoMessage()    {}
 func (*PutClusterConfigRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{23}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{23}
 }
 func (m *PutClusterConfigRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1443,7 +1443,7 @@ func (m *PutClusterConfigResponse) Reset()         { *m = PutClusterConfigRespon
 func (m *PutClusterConfigResponse) String() string { return proto.CompactTextString(m) }
 func (*PutClusterConfigResponse) ProtoMessage()    {}
 func (*PutClusterConfigResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{24}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{24}
 }
 func (m *PutClusterConfigResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1496,7 +1496,7 @@ func (m *Member) Reset()         { *m = Member{} }
 func (m *Member) String() string { return proto.CompactTextString(m) }
 func (*Member) ProtoMessage()    {}
 func (*Member) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{25}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{25}
 }
 func (m *Member) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1571,7 +1571,7 @@ func (m *GetMembersRequest) Reset()         { *m = GetMembersRequest{} }
 func (m *GetMembersRequest) String() string { return proto.CompactTextString(m) }
 func (*GetMembersRequest) ProtoMessage()    {}
 func (*GetMembersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{26}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{26}
 }
 func (m *GetMembersRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1621,7 +1621,7 @@ func (m *GetMembersResponse) Reset()         { *m = GetMembersResponse{} }
 func (m *GetMembersResponse) String() string { return proto.CompactTextString(m) }
 func (*GetMembersResponse) ProtoMessage()    {}
 func (*GetMembersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{27}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{27}
 }
 func (m *GetMembersResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1690,7 +1690,7 @@ func (m *PeerStats) Reset()         { *m = PeerStats{} }
 func (m *PeerStats) String() string { return proto.CompactTextString(m) }
 func (*PeerStats) ProtoMessage()    {}
 func (*PeerStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{28}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{28}
 }
 func (m *PeerStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1764,7 +1764,7 @@ func (m *RegionHeartbeatRequest) Reset()         { *m = RegionHeartbeatRequest{}
 func (m *RegionHeartbeatRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionHeartbeatRequest) ProtoMessage()    {}
 func (*RegionHeartbeatRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{29}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{29}
 }
 func (m *RegionHeartbeatRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1889,7 +1889,7 @@ func (m *ChangePeer) Reset()         { *m = ChangePeer{} }
 func (m *ChangePeer) String() string { return proto.CompactTextString(m) }
 func (*ChangePeer) ProtoMessage()    {}
 func (*ChangePeer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{30}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{30}
 }
 func (m *ChangePeer) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1943,7 +1943,7 @@ func (m *TransferLeader) Reset()         { *m = TransferLeader{} }
 func (m *TransferLeader) String() string { return proto.CompactTextString(m) }
 func (*TransferLeader) ProtoMessage()    {}
 func (*TransferLeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{31}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{31}
 }
 func (m *TransferLeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1990,7 +1990,7 @@ func (m *Merge) Reset()         { *m = Merge{} }
 func (m *Merge) String() string { return proto.CompactTextString(m) }
 func (*Merge) ProtoMessage()    {}
 func (*Merge) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{32}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{32}
 }
 func (m *Merge) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2037,7 +2037,7 @@ func (m *SplitRegion) Reset()         { *m = SplitRegion{} }
 func (m *SplitRegion) String() string { return proto.CompactTextString(m) }
 func (*SplitRegion) ProtoMessage()    {}
 func (*SplitRegion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{33}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{33}
 }
 func (m *SplitRegion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2109,7 +2109,7 @@ func (m *RegionHeartbeatResponse) Reset()         { *m = RegionHeartbeatResponse
 func (m *RegionHeartbeatResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionHeartbeatResponse) ProtoMessage()    {}
 func (*RegionHeartbeatResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{34}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{34}
 }
 func (m *RegionHeartbeatResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2206,7 +2206,7 @@ func (m *AskSplitRequest) Reset()         { *m = AskSplitRequest{} }
 func (m *AskSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AskSplitRequest) ProtoMessage()    {}
 func (*AskSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{35}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{35}
 }
 func (m *AskSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2266,7 +2266,7 @@ func (m *AskSplitResponse) Reset()         { *m = AskSplitResponse{} }
 func (m *AskSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AskSplitResponse) ProtoMessage()    {}
 func (*AskSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{36}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{36}
 }
 func (m *AskSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2329,7 +2329,7 @@ func (m *ReportSplitRequest) Reset()         { *m = ReportSplitRequest{} }
 func (m *ReportSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*ReportSplitRequest) ProtoMessage()    {}
 func (*ReportSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{37}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{37}
 }
 func (m *ReportSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2390,7 +2390,7 @@ func (m *ReportSplitResponse) Reset()         { *m = ReportSplitResponse{} }
 func (m *ReportSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*ReportSplitResponse) ProtoMessage()    {}
 func (*ReportSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{38}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{38}
 }
 func (m *ReportSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2439,7 +2439,7 @@ func (m *AskBatchSplitRequest) Reset()         { *m = AskBatchSplitRequest{} }
 func (m *AskBatchSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*AskBatchSplitRequest) ProtoMessage()    {}
 func (*AskBatchSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{39}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{39}
 }
 func (m *AskBatchSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2501,7 +2501,7 @@ func (m *SplitID) Reset()         { *m = SplitID{} }
 func (m *SplitID) String() string { return proto.CompactTextString(m) }
 func (*SplitID) ProtoMessage()    {}
 func (*SplitID) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{40}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{40}
 }
 func (m *SplitID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2556,7 +2556,7 @@ func (m *AskBatchSplitResponse) Reset()         { *m = AskBatchSplitResponse{} }
 func (m *AskBatchSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*AskBatchSplitResponse) ProtoMessage()    {}
 func (*AskBatchSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{41}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{41}
 }
 func (m *AskBatchSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2611,7 +2611,7 @@ func (m *ReportBatchSplitRequest) Reset()         { *m = ReportBatchSplitRequest
 func (m *ReportBatchSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*ReportBatchSplitRequest) ProtoMessage()    {}
 func (*ReportBatchSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{42}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{42}
 }
 func (m *ReportBatchSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2665,7 +2665,7 @@ func (m *ReportBatchSplitResponse) Reset()         { *m = ReportBatchSplitRespon
 func (m *ReportBatchSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*ReportBatchSplitResponse) ProtoMessage()    {}
 func (*ReportBatchSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{43}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{43}
 }
 func (m *ReportBatchSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2715,7 +2715,7 @@ func (m *TimeInterval) Reset()         { *m = TimeInterval{} }
 func (m *TimeInterval) String() string { return proto.CompactTextString(m) }
 func (*TimeInterval) ProtoMessage()    {}
 func (*TimeInterval) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{44}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{44}
 }
 func (m *TimeInterval) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2797,7 +2797,7 @@ func (m *StoreStats) Reset()         { *m = StoreStats{} }
 func (m *StoreStats) String() string { return proto.CompactTextString(m) }
 func (*StoreStats) ProtoMessage()    {}
 func (*StoreStats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{45}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{45}
 }
 func (m *StoreStats) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2943,7 +2943,7 @@ func (m *StoreHeartbeatRequest) Reset()         { *m = StoreHeartbeatRequest{} }
 func (m *StoreHeartbeatRequest) String() string { return proto.CompactTextString(m) }
 func (*StoreHeartbeatRequest) ProtoMessage()    {}
 func (*StoreHeartbeatRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{46}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{46}
 }
 func (m *StoreHeartbeatRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2997,7 +2997,7 @@ func (m *StoreHeartbeatResponse) Reset()         { *m = StoreHeartbeatResponse{}
 func (m *StoreHeartbeatResponse) String() string { return proto.CompactTextString(m) }
 func (*StoreHeartbeatResponse) ProtoMessage()    {}
 func (*StoreHeartbeatResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{47}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{47}
 }
 func (m *StoreHeartbeatResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3049,7 +3049,7 @@ func (m *ScatterRegionRequest) Reset()         { *m = ScatterRegionRequest{} }
 func (m *ScatterRegionRequest) String() string { return proto.CompactTextString(m) }
 func (*ScatterRegionRequest) ProtoMessage()    {}
 func (*ScatterRegionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{48}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{48}
 }
 func (m *ScatterRegionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3117,7 +3117,7 @@ func (m *ScatterRegionResponse) Reset()         { *m = ScatterRegionResponse{} }
 func (m *ScatterRegionResponse) String() string { return proto.CompactTextString(m) }
 func (*ScatterRegionResponse) ProtoMessage()    {}
 func (*ScatterRegionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{49}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{49}
 }
 func (m *ScatterRegionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3164,7 +3164,7 @@ func (m *GetGCSafePointRequest) Reset()         { *m = GetGCSafePointRequest{} }
 func (m *GetGCSafePointRequest) String() string { return proto.CompactTextString(m) }
 func (*GetGCSafePointRequest) ProtoMessage()    {}
 func (*GetGCSafePointRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{50}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{50}
 }
 func (m *GetGCSafePointRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3212,7 +3212,7 @@ func (m *GetGCSafePointResponse) Reset()         { *m = GetGCSafePointResponse{}
 func (m *GetGCSafePointResponse) String() string { return proto.CompactTextString(m) }
 func (*GetGCSafePointResponse) ProtoMessage()    {}
 func (*GetGCSafePointResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{51}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{51}
 }
 func (m *GetGCSafePointResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3267,7 +3267,7 @@ func (m *UpdateGCSafePointRequest) Reset()         { *m = UpdateGCSafePointReque
 func (m *UpdateGCSafePointRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdateGCSafePointRequest) ProtoMessage()    {}
 func (*UpdateGCSafePointRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{52}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{52}
 }
 func (m *UpdateGCSafePointRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3322,7 +3322,7 @@ func (m *UpdateGCSafePointResponse) Reset()         { *m = UpdateGCSafePointResp
 func (m *UpdateGCSafePointResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateGCSafePointResponse) ProtoMessage()    {}
 func (*UpdateGCSafePointResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{53}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{53}
 }
 func (m *UpdateGCSafePointResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3380,7 +3380,7 @@ func (m *SyncRegionRequest) Reset()         { *m = SyncRegionRequest{} }
 func (m *SyncRegionRequest) String() string { return proto.CompactTextString(m) }
 func (*SyncRegionRequest) ProtoMessage()    {}
 func (*SyncRegionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{54}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{54}
 }
 func (m *SyncRegionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3445,7 +3445,7 @@ func (m *SyncRegionResponse) Reset()         { *m = SyncRegionResponse{} }
 func (m *SyncRegionResponse) String() string { return proto.CompactTextString(m) }
 func (*SyncRegionResponse) ProtoMessage()    {}
 func (*SyncRegionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{55}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{55}
 }
 func (m *SyncRegionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3507,7 +3507,7 @@ func (m *GetOperatorRequest) Reset()         { *m = GetOperatorRequest{} }
 func (m *GetOperatorRequest) String() string { return proto.CompactTextString(m) }
 func (*GetOperatorRequest) ProtoMessage()    {}
 func (*GetOperatorRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{56}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{56}
 }
 func (m *GetOperatorRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3565,7 +3565,7 @@ func (m *GetOperatorResponse) Reset()         { *m = GetOperatorResponse{} }
 func (m *GetOperatorResponse) String() string { return proto.CompactTextString(m) }
 func (*GetOperatorResponse) ProtoMessage()    {}
 func (*GetOperatorResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_pdpb_bb7295ce1d09d888, []int{57}
+	return fileDescriptor_pdpb_645eecd97f4f83ac, []int{57}
 }
 func (m *GetOperatorResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -15450,9 +15450,9 @@ var (
 	ErrIntOverflowPdpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("pdpb.proto", fileDescriptor_pdpb_bb7295ce1d09d888) }
+func init() { proto.RegisterFile("pdpb.proto", fileDescriptor_pdpb_645eecd97f4f83ac) }
 
-var fileDescriptor_pdpb_bb7295ce1d09d888 = []byte{
+var fileDescriptor_pdpb_645eecd97f4f83ac = []byte{
 	// 2593 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5a, 0xcd, 0x6f, 0x1b, 0xc7,
 	0x15, 0xd7, 0x52, 0x24, 0x45, 0x3e, 0x7e, 0x6a, 0xac, 0x0f, 0x9a, 0xfe, 0xcc, 0xd8, 0x4d, 0x65,

--- a/pkg/raft_cmdpb/raft_cmdpb.pb.go
+++ b/pkg/raft_cmdpb/raft_cmdpb.pb.go
@@ -68,7 +68,7 @@ func (x CmdType) String() string {
 	return proto.EnumName(CmdType_name, int32(x))
 }
 func (CmdType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{0}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{0}
 }
 
 type AdminCmdType int32
@@ -119,7 +119,7 @@ func (x AdminCmdType) String() string {
 	return proto.EnumName(AdminCmdType_name, int32(x))
 }
 func (AdminCmdType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{1}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{1}
 }
 
 type StatusCmdType int32
@@ -145,7 +145,7 @@ func (x StatusCmdType) String() string {
 	return proto.EnumName(StatusCmdType_name, int32(x))
 }
 func (StatusCmdType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{2}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{2}
 }
 
 type GetRequest struct {
@@ -160,7 +160,7 @@ func (m *GetRequest) Reset()         { *m = GetRequest{} }
 func (m *GetRequest) String() string { return proto.CompactTextString(m) }
 func (*GetRequest) ProtoMessage()    {}
 func (*GetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{0}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{0}
 }
 func (m *GetRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -214,7 +214,7 @@ func (m *GetResponse) Reset()         { *m = GetResponse{} }
 func (m *GetResponse) String() string { return proto.CompactTextString(m) }
 func (*GetResponse) ProtoMessage()    {}
 func (*GetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{1}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{1}
 }
 func (m *GetResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -263,7 +263,7 @@ func (m *PutRequest) Reset()         { *m = PutRequest{} }
 func (m *PutRequest) String() string { return proto.CompactTextString(m) }
 func (*PutRequest) ProtoMessage()    {}
 func (*PutRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{2}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{2}
 }
 func (m *PutRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -323,7 +323,7 @@ func (m *PutResponse) Reset()         { *m = PutResponse{} }
 func (m *PutResponse) String() string { return proto.CompactTextString(m) }
 func (*PutResponse) ProtoMessage()    {}
 func (*PutResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{3}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{3}
 }
 func (m *PutResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -364,7 +364,7 @@ func (m *DeleteRequest) Reset()         { *m = DeleteRequest{} }
 func (m *DeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRequest) ProtoMessage()    {}
 func (*DeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{4}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{4}
 }
 func (m *DeleteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -417,7 +417,7 @@ func (m *DeleteResponse) Reset()         { *m = DeleteResponse{} }
 func (m *DeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteResponse) ProtoMessage()    {}
 func (*DeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{5}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{5}
 }
 func (m *DeleteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -459,7 +459,7 @@ func (m *DeleteRangeRequest) Reset()         { *m = DeleteRangeRequest{} }
 func (m *DeleteRangeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeRequest) ProtoMessage()    {}
 func (*DeleteRangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{6}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{6}
 }
 func (m *DeleteRangeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -519,7 +519,7 @@ func (m *DeleteRangeResponse) Reset()         { *m = DeleteRangeResponse{} }
 func (m *DeleteRangeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRangeResponse) ProtoMessage()    {}
 func (*DeleteRangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{7}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{7}
 }
 func (m *DeleteRangeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -558,7 +558,7 @@ func (m *SnapRequest) Reset()         { *m = SnapRequest{} }
 func (m *SnapRequest) String() string { return proto.CompactTextString(m) }
 func (*SnapRequest) ProtoMessage()    {}
 func (*SnapRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{8}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{8}
 }
 func (m *SnapRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -598,7 +598,7 @@ func (m *SnapResponse) Reset()         { *m = SnapResponse{} }
 func (m *SnapResponse) String() string { return proto.CompactTextString(m) }
 func (*SnapResponse) ProtoMessage()    {}
 func (*SnapResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{9}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{9}
 }
 func (m *SnapResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -647,7 +647,7 @@ func (m *PrewriteRequest) Reset()         { *m = PrewriteRequest{} }
 func (m *PrewriteRequest) String() string { return proto.CompactTextString(m) }
 func (*PrewriteRequest) ProtoMessage()    {}
 func (*PrewriteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{10}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{10}
 }
 func (m *PrewriteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -707,7 +707,7 @@ func (m *PrewriteResponse) Reset()         { *m = PrewriteResponse{} }
 func (m *PrewriteResponse) String() string { return proto.CompactTextString(m) }
 func (*PrewriteResponse) ProtoMessage()    {}
 func (*PrewriteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{11}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{11}
 }
 func (m *PrewriteResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -747,7 +747,7 @@ func (m *IngestSSTRequest) Reset()         { *m = IngestSSTRequest{} }
 func (m *IngestSSTRequest) String() string { return proto.CompactTextString(m) }
 func (*IngestSSTRequest) ProtoMessage()    {}
 func (*IngestSSTRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{12}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{12}
 }
 func (m *IngestSSTRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -793,7 +793,7 @@ func (m *IngestSSTResponse) Reset()         { *m = IngestSSTResponse{} }
 func (m *IngestSSTResponse) String() string { return proto.CompactTextString(m) }
 func (*IngestSSTResponse) ProtoMessage()    {}
 func (*IngestSSTResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{13}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{13}
 }
 func (m *IngestSSTResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -840,7 +840,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{14}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{14}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -943,7 +943,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{15}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{15}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1041,7 +1041,7 @@ func (m *ChangePeerRequest) Reset()         { *m = ChangePeerRequest{} }
 func (m *ChangePeerRequest) String() string { return proto.CompactTextString(m) }
 func (*ChangePeerRequest) ProtoMessage()    {}
 func (*ChangePeerRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{16}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{16}
 }
 func (m *ChangePeerRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1095,7 +1095,7 @@ func (m *ChangePeerResponse) Reset()         { *m = ChangePeerResponse{} }
 func (m *ChangePeerResponse) String() string { return proto.CompactTextString(m) }
 func (*ChangePeerResponse) ProtoMessage()    {}
 func (*ChangePeerResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{17}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{17}
 }
 func (m *ChangePeerResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1154,7 +1154,7 @@ func (m *SplitRequest) Reset()         { *m = SplitRequest{} }
 func (m *SplitRequest) String() string { return proto.CompactTextString(m) }
 func (*SplitRequest) ProtoMessage()    {}
 func (*SplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{18}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{18}
 }
 func (m *SplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1224,7 +1224,7 @@ func (m *SplitResponse) Reset()         { *m = SplitResponse{} }
 func (m *SplitResponse) String() string { return proto.CompactTextString(m) }
 func (*SplitResponse) ProtoMessage()    {}
 func (*SplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{19}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{19}
 }
 func (m *SplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1281,7 +1281,7 @@ func (m *BatchSplitRequest) Reset()         { *m = BatchSplitRequest{} }
 func (m *BatchSplitRequest) String() string { return proto.CompactTextString(m) }
 func (*BatchSplitRequest) ProtoMessage()    {}
 func (*BatchSplitRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{20}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{20}
 }
 func (m *BatchSplitRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1335,7 +1335,7 @@ func (m *BatchSplitResponse) Reset()         { *m = BatchSplitResponse{} }
 func (m *BatchSplitResponse) String() string { return proto.CompactTextString(m) }
 func (*BatchSplitResponse) ProtoMessage()    {}
 func (*BatchSplitResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{21}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{21}
 }
 func (m *BatchSplitResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1383,7 +1383,7 @@ func (m *CompactLogRequest) Reset()         { *m = CompactLogRequest{} }
 func (m *CompactLogRequest) String() string { return proto.CompactTextString(m) }
 func (*CompactLogRequest) ProtoMessage()    {}
 func (*CompactLogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{22}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{22}
 }
 func (m *CompactLogRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1436,7 +1436,7 @@ func (m *CompactLogResponse) Reset()         { *m = CompactLogResponse{} }
 func (m *CompactLogResponse) String() string { return proto.CompactTextString(m) }
 func (*CompactLogResponse) ProtoMessage()    {}
 func (*CompactLogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{23}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{23}
 }
 func (m *CompactLogResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1476,7 +1476,7 @@ func (m *TransferLeaderRequest) Reset()         { *m = TransferLeaderRequest{} }
 func (m *TransferLeaderRequest) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaderRequest) ProtoMessage()    {}
 func (*TransferLeaderRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{24}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{24}
 }
 func (m *TransferLeaderRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1522,7 +1522,7 @@ func (m *TransferLeaderResponse) Reset()         { *m = TransferLeaderResponse{}
 func (m *TransferLeaderResponse) String() string { return proto.CompactTextString(m) }
 func (*TransferLeaderResponse) ProtoMessage()    {}
 func (*TransferLeaderResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{25}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{25}
 }
 func (m *TransferLeaderResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1563,7 +1563,7 @@ func (m *VerifyHashRequest) Reset()         { *m = VerifyHashRequest{} }
 func (m *VerifyHashRequest) String() string { return proto.CompactTextString(m) }
 func (*VerifyHashRequest) ProtoMessage()    {}
 func (*VerifyHashRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{26}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{26}
 }
 func (m *VerifyHashRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1616,7 +1616,7 @@ func (m *VerifyHashResponse) Reset()         { *m = VerifyHashResponse{} }
 func (m *VerifyHashResponse) String() string { return proto.CompactTextString(m) }
 func (*VerifyHashResponse) ProtoMessage()    {}
 func (*VerifyHashResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{27}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{27}
 }
 func (m *VerifyHashResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1657,7 +1657,7 @@ func (m *PrepareMergeRequest) Reset()         { *m = PrepareMergeRequest{} }
 func (m *PrepareMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*PrepareMergeRequest) ProtoMessage()    {}
 func (*PrepareMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{28}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{28}
 }
 func (m *PrepareMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1710,7 +1710,7 @@ func (m *PrepareMergeResponse) Reset()         { *m = PrepareMergeResponse{} }
 func (m *PrepareMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*PrepareMergeResponse) ProtoMessage()    {}
 func (*PrepareMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{29}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{29}
 }
 func (m *PrepareMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1752,7 +1752,7 @@ func (m *CommitMergeRequest) Reset()         { *m = CommitMergeRequest{} }
 func (m *CommitMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*CommitMergeRequest) ProtoMessage()    {}
 func (*CommitMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{30}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{30}
 }
 func (m *CommitMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1812,7 +1812,7 @@ func (m *CommitMergeResponse) Reset()         { *m = CommitMergeResponse{} }
 func (m *CommitMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*CommitMergeResponse) ProtoMessage()    {}
 func (*CommitMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{31}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{31}
 }
 func (m *CommitMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1852,7 +1852,7 @@ func (m *RollbackMergeRequest) Reset()         { *m = RollbackMergeRequest{} }
 func (m *RollbackMergeRequest) String() string { return proto.CompactTextString(m) }
 func (*RollbackMergeRequest) ProtoMessage()    {}
 func (*RollbackMergeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{32}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{32}
 }
 func (m *RollbackMergeRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1898,7 +1898,7 @@ func (m *RollbackMergeResponse) Reset()         { *m = RollbackMergeResponse{} }
 func (m *RollbackMergeResponse) String() string { return proto.CompactTextString(m) }
 func (*RollbackMergeResponse) ProtoMessage()    {}
 func (*RollbackMergeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{33}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{33}
 }
 func (m *RollbackMergeResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1947,7 +1947,7 @@ func (m *AdminRequest) Reset()         { *m = AdminRequest{} }
 func (m *AdminRequest) String() string { return proto.CompactTextString(m) }
 func (*AdminRequest) ProtoMessage()    {}
 func (*AdminRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{34}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{34}
 }
 func (m *AdminRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2067,7 +2067,7 @@ func (m *AdminResponse) Reset()         { *m = AdminResponse{} }
 func (m *AdminResponse) String() string { return proto.CompactTextString(m) }
 func (*AdminResponse) ProtoMessage()    {}
 func (*AdminResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{35}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{35}
 }
 func (m *AdminResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2178,7 +2178,7 @@ func (m *RegionLeaderRequest) Reset()         { *m = RegionLeaderRequest{} }
 func (m *RegionLeaderRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionLeaderRequest) ProtoMessage()    {}
 func (*RegionLeaderRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{36}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{36}
 }
 func (m *RegionLeaderRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2218,7 +2218,7 @@ func (m *RegionLeaderResponse) Reset()         { *m = RegionLeaderResponse{} }
 func (m *RegionLeaderResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionLeaderResponse) ProtoMessage()    {}
 func (*RegionLeaderResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{37}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{37}
 }
 func (m *RegionLeaderResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2273,7 +2273,7 @@ func (m *RegionDetailRequest) Reset()         { *m = RegionDetailRequest{} }
 func (m *RegionDetailRequest) String() string { return proto.CompactTextString(m) }
 func (*RegionDetailRequest) ProtoMessage()    {}
 func (*RegionDetailRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{38}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{38}
 }
 func (m *RegionDetailRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2314,7 +2314,7 @@ func (m *RegionDetailResponse) Reset()         { *m = RegionDetailResponse{} }
 func (m *RegionDetailResponse) String() string { return proto.CompactTextString(m) }
 func (*RegionDetailResponse) ProtoMessage()    {}
 func (*RegionDetailResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{39}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{39}
 }
 func (m *RegionDetailResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2370,7 +2370,7 @@ func (m *StatusRequest) Reset()         { *m = StatusRequest{} }
 func (m *StatusRequest) String() string { return proto.CompactTextString(m) }
 func (*StatusRequest) ProtoMessage()    {}
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{40}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{40}
 }
 func (m *StatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2433,7 +2433,7 @@ func (m *StatusResponse) Reset()         { *m = StatusResponse{} }
 func (m *StatusResponse) String() string { return proto.CompactTextString(m) }
 func (*StatusResponse) ProtoMessage()    {}
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{41}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{41}
 }
 func (m *StatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2502,7 +2502,7 @@ func (m *RaftRequestHeader) Reset()         { *m = RaftRequestHeader{} }
 func (m *RaftRequestHeader) String() string { return proto.CompactTextString(m) }
 func (*RaftRequestHeader) ProtoMessage()    {}
 func (*RaftRequestHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{42}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{42}
 }
 func (m *RaftRequestHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2593,7 +2593,7 @@ func (m *RaftResponseHeader) Reset()         { *m = RaftResponseHeader{} }
 func (m *RaftResponseHeader) String() string { return proto.CompactTextString(m) }
 func (*RaftResponseHeader) ProtoMessage()    {}
 func (*RaftResponseHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{43}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{43}
 }
 func (m *RaftResponseHeader) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2659,7 +2659,7 @@ func (m *RaftCmdRequest) Reset()         { *m = RaftCmdRequest{} }
 func (m *RaftCmdRequest) String() string { return proto.CompactTextString(m) }
 func (*RaftCmdRequest) ProtoMessage()    {}
 func (*RaftCmdRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{44}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{44}
 }
 func (m *RaftCmdRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2730,7 +2730,7 @@ func (m *RaftCmdResponse) Reset()         { *m = RaftCmdResponse{} }
 func (m *RaftCmdResponse) String() string { return proto.CompactTextString(m) }
 func (*RaftCmdResponse) ProtoMessage()    {}
 func (*RaftCmdResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d, []int{45}
+	return fileDescriptor_raft_cmdpb_a959bfc7bc86e41c, []int{45}
 }
 func (m *RaftCmdResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -11022,9 +11022,9 @@ var (
 	ErrIntOverflowRaftCmdpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("raft_cmdpb.proto", fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d) }
+func init() { proto.RegisterFile("raft_cmdpb.proto", fileDescriptor_raft_cmdpb_a959bfc7bc86e41c) }
 
-var fileDescriptor_raft_cmdpb_02cfcfa621ac6f2d = []byte{
+var fileDescriptor_raft_cmdpb_a959bfc7bc86e41c = []byte{
 	// 2009 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x58, 0x4f, 0x73, 0x1b, 0x49,
 	0x15, 0xcf, 0xe8, 0xbf, 0x9f, 0x34, 0xf2, 0xb8, 0x6d, 0xc7, 0x4a, 0xb2, 0x28, 0xca, 0x6c, 0x08,

--- a/pkg/raft_serverpb/raft_serverpb.pb.go
+++ b/pkg/raft_serverpb/raft_serverpb.pb.go
@@ -52,7 +52,7 @@ func (x PeerState) String() string {
 	return proto.EnumName(PeerState_name, int32(x))
 }
 func (PeerState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{0}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{0}
 }
 
 type RaftMessage struct {
@@ -77,7 +77,7 @@ func (m *RaftMessage) Reset()         { *m = RaftMessage{} }
 func (m *RaftMessage) String() string { return proto.CompactTextString(m) }
 func (*RaftMessage) ProtoMessage()    {}
 func (*RaftMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{0}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{0}
 }
 func (m *RaftMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -181,7 +181,7 @@ func (m *RaftTruncatedState) Reset()         { *m = RaftTruncatedState{} }
 func (m *RaftTruncatedState) String() string { return proto.CompactTextString(m) }
 func (*RaftTruncatedState) ProtoMessage()    {}
 func (*RaftTruncatedState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{1}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{1}
 }
 func (m *RaftTruncatedState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -237,7 +237,7 @@ func (m *SnapshotCFFile) Reset()         { *m = SnapshotCFFile{} }
 func (m *SnapshotCFFile) String() string { return proto.CompactTextString(m) }
 func (*SnapshotCFFile) ProtoMessage()    {}
 func (*SnapshotCFFile) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{2}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{2}
 }
 func (m *SnapshotCFFile) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -298,7 +298,7 @@ func (m *SnapshotMeta) Reset()         { *m = SnapshotMeta{} }
 func (m *SnapshotMeta) String() string { return proto.CompactTextString(m) }
 func (*SnapshotMeta) ProtoMessage()    {}
 func (*SnapshotMeta) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{3}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{3}
 }
 func (m *SnapshotMeta) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -346,7 +346,7 @@ func (m *SnapshotChunk) Reset()         { *m = SnapshotChunk{} }
 func (m *SnapshotChunk) String() string { return proto.CompactTextString(m) }
 func (*SnapshotChunk) ProtoMessage()    {}
 func (*SnapshotChunk) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{4}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{4}
 }
 func (m *SnapshotChunk) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -399,7 +399,7 @@ func (m *Done) Reset()         { *m = Done{} }
 func (m *Done) String() string { return proto.CompactTextString(m) }
 func (*Done) ProtoMessage()    {}
 func (*Done) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{5}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{5}
 }
 func (m *Done) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -440,7 +440,7 @@ func (m *KeyValue) Reset()         { *m = KeyValue{} }
 func (m *KeyValue) String() string { return proto.CompactTextString(m) }
 func (*KeyValue) ProtoMessage()    {}
 func (*KeyValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{6}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{6}
 }
 func (m *KeyValue) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -498,7 +498,7 @@ func (m *RaftSnapshotData) Reset()         { *m = RaftSnapshotData{} }
 func (m *RaftSnapshotData) String() string { return proto.CompactTextString(m) }
 func (*RaftSnapshotData) ProtoMessage()    {}
 func (*RaftSnapshotData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{7}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{7}
 }
 func (m *RaftSnapshotData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -574,7 +574,7 @@ func (m *StoreIdent) Reset()         { *m = StoreIdent{} }
 func (m *StoreIdent) String() string { return proto.CompactTextString(m) }
 func (*StoreIdent) ProtoMessage()    {}
 func (*StoreIdent) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{8}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{8}
 }
 func (m *StoreIdent) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -629,7 +629,7 @@ func (m *RaftLocalState) Reset()         { *m = RaftLocalState{} }
 func (m *RaftLocalState) String() string { return proto.CompactTextString(m) }
 func (*RaftLocalState) ProtoMessage()    {}
 func (*RaftLocalState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{9}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{9}
 }
 func (m *RaftLocalState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -684,7 +684,7 @@ func (m *RaftApplyState) Reset()         { *m = RaftApplyState{} }
 func (m *RaftApplyState) String() string { return proto.CompactTextString(m) }
 func (*RaftApplyState) ProtoMessage()    {}
 func (*RaftApplyState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{10}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{10}
 }
 func (m *RaftApplyState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -740,7 +740,7 @@ func (m *MergeState) Reset()         { *m = MergeState{} }
 func (m *MergeState) String() string { return proto.CompactTextString(m) }
 func (*MergeState) ProtoMessage()    {}
 func (*MergeState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{11}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{11}
 }
 func (m *MergeState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -803,7 +803,7 @@ func (m *RegionLocalState) Reset()         { *m = RegionLocalState{} }
 func (m *RegionLocalState) String() string { return proto.CompactTextString(m) }
 func (*RegionLocalState) ProtoMessage()    {}
 func (*RegionLocalState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_raft_serverpb_e70f8fadb12392d2, []int{12}
+	return fileDescriptor_raft_serverpb_7cffb7d3fba4d6da, []int{12}
 }
 func (m *RegionLocalState) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3413,9 +3413,9 @@ var (
 	ErrIntOverflowRaftServerpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("raft_serverpb.proto", fileDescriptor_raft_serverpb_e70f8fadb12392d2) }
+func init() { proto.RegisterFile("raft_serverpb.proto", fileDescriptor_raft_serverpb_7cffb7d3fba4d6da) }
 
-var fileDescriptor_raft_serverpb_e70f8fadb12392d2 = []byte{
+var fileDescriptor_raft_serverpb_7cffb7d3fba4d6da = []byte{
 	// 873 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x55, 0xdd, 0x6e, 0xe3, 0x44,
 	0x14, 0x5e, 0x27, 0xae, 0x63, 0x9f, 0x38, 0xd9, 0x68, 0x16, 0xb1, 0xde, 0x56, 0x5b, 0x65, 0x8d,

--- a/pkg/tikvpb/tikvpb.pb.go
+++ b/pkg/tikvpb/tikvpb.pb.go
@@ -46,7 +46,7 @@ func (m *BatchCommandsRequest) Reset()         { *m = BatchCommandsRequest{} }
 func (m *BatchCommandsRequest) String() string { return proto.CompactTextString(m) }
 func (*BatchCommandsRequest) ProtoMessage()    {}
 func (*BatchCommandsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tikvpb_f13fe53945c7f460, []int{0}
+	return fileDescriptor_tikvpb_e7302e256bdfa766, []int{0}
 }
 func (m *BatchCommandsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -123,7 +123,7 @@ func (m *BatchCommandsRequest_Request) Reset()         { *m = BatchCommandsReque
 func (m *BatchCommandsRequest_Request) String() string { return proto.CompactTextString(m) }
 func (*BatchCommandsRequest_Request) ProtoMessage()    {}
 func (*BatchCommandsRequest_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tikvpb_f13fe53945c7f460, []int{0, 0}
+	return fileDescriptor_tikvpb_e7302e256bdfa766, []int{0, 0}
 }
 func (m *BatchCommandsRequest_Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -877,7 +877,7 @@ func (m *BatchCommandsResponse) Reset()         { *m = BatchCommandsResponse{} }
 func (m *BatchCommandsResponse) String() string { return proto.CompactTextString(m) }
 func (*BatchCommandsResponse) ProtoMessage()    {}
 func (*BatchCommandsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tikvpb_f13fe53945c7f460, []int{1}
+	return fileDescriptor_tikvpb_e7302e256bdfa766, []int{1}
 }
 func (m *BatchCommandsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -961,7 +961,7 @@ func (m *BatchCommandsResponse_Response) Reset()         { *m = BatchCommandsRes
 func (m *BatchCommandsResponse_Response) String() string { return proto.CompactTextString(m) }
 func (*BatchCommandsResponse_Response) ProtoMessage()    {}
 func (*BatchCommandsResponse_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tikvpb_f13fe53945c7f460, []int{1, 0}
+	return fileDescriptor_tikvpb_e7302e256bdfa766, []int{1, 0}
 }
 func (m *BatchCommandsResponse_Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1712,7 +1712,7 @@ func (m *BatchRaftMessage) Reset()         { *m = BatchRaftMessage{} }
 func (m *BatchRaftMessage) String() string { return proto.CompactTextString(m) }
 func (*BatchRaftMessage) ProtoMessage()    {}
 func (*BatchRaftMessage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_tikvpb_f13fe53945c7f460, []int{2}
+	return fileDescriptor_tikvpb_e7302e256bdfa766, []int{2}
 }
 func (m *BatchRaftMessage) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -6340,9 +6340,9 @@ var (
 	ErrIntOverflowTikvpb   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("tikvpb.proto", fileDescriptor_tikvpb_f13fe53945c7f460) }
+func init() { proto.RegisterFile("tikvpb.proto", fileDescriptor_tikvpb_e7302e256bdfa766) }
 
-var fileDescriptor_tikvpb_f13fe53945c7f460 = []byte{
+var fileDescriptor_tikvpb_e7302e256bdfa766 = []byte{
 	// 1437 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x98, 0xdf, 0x72, 0xdb, 0xc4,
 	0x17, 0xc7, 0xe5, 0xc4, 0x4d, 0x9d, 0x75, 0xd3, 0x26, 0x27, 0x49, 0xa3, 0xec, 0xcf, 0x4d, 0xf3,

--- a/src/protobuf/coprocessor.rs
+++ b/src/protobuf/coprocessor.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KeyRange {
     // message fields
     pub start: ::std::vec::Vec<u8>,
@@ -187,19 +187,13 @@ impl ::protobuf::Clear for KeyRange {
     }
 }
 
-impl ::std::fmt::Debug for KeyRange {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KeyRange {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Request {
     // message fields
     pub context: ::protobuf::SingularPtrField<super::kvrpcpb::Context>,
@@ -454,19 +448,13 @@ impl ::protobuf::Clear for Request {
     }
 }
 
-impl ::std::fmt::Debug for Request {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Request {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Response {
     // message fields
     pub data: ::std::vec::Vec<u8>,
@@ -837,12 +825,6 @@ impl ::protobuf::Clear for Response {
         self.clear_range();
         self.clear_exec_details();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for Response {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/debugpb.rs
+++ b/src/protobuf/debugpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRequest {
     // message fields
     pub db: DB,
@@ -213,19 +213,13 @@ impl ::protobuf::Clear for GetRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetResponse {
     // message fields
     pub value: ::std::vec::Vec<u8>,
@@ -354,19 +348,13 @@ impl ::protobuf::Clear for GetResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftLogRequest {
     // message fields
     pub region_id: u64,
@@ -518,19 +506,13 @@ impl ::protobuf::Clear for RaftLogRequest {
     }
 }
 
-impl ::std::fmt::Debug for RaftLogRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftLogRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftLogResponse {
     // message fields
     pub entry: ::protobuf::SingularPtrField<super::eraftpb::Entry>,
@@ -674,19 +656,13 @@ impl ::protobuf::Clear for RaftLogResponse {
     }
 }
 
-impl ::std::fmt::Debug for RaftLogResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftLogResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionInfoRequest {
     // message fields
     pub region_id: u64,
@@ -808,19 +784,13 @@ impl ::protobuf::Clear for RegionInfoRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionInfoRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionInfoRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionInfoResponse {
     // message fields
     pub raft_local_state: ::protobuf::SingularPtrField<super::raft_serverpb::RaftLocalState>,
@@ -1068,19 +1038,13 @@ impl ::protobuf::Clear for RegionInfoResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionInfoResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionInfoResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionSizeRequest {
     // message fields
     pub region_id: u64,
@@ -1238,19 +1202,13 @@ impl ::protobuf::Clear for RegionSizeRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionSizeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionSizeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionSizeResponse {
     // message fields
     pub entries: ::protobuf::RepeatedField<RegionSizeResponse_Entry>,
@@ -1386,19 +1344,13 @@ impl ::protobuf::Clear for RegionSizeResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionSizeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionSizeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionSizeResponse_Entry {
     // message fields
     pub cf: ::std::string::String,
@@ -1557,19 +1509,13 @@ impl ::protobuf::Clear for RegionSizeResponse_Entry {
     }
 }
 
-impl ::std::fmt::Debug for RegionSizeResponse_Entry {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionSizeResponse_Entry {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanMvccRequest {
     // message fields
     pub from_key: ::std::vec::Vec<u8>,
@@ -1765,19 +1711,13 @@ impl ::protobuf::Clear for ScanMvccRequest {
     }
 }
 
-impl ::std::fmt::Debug for ScanMvccRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanMvccRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanMvccResponse {
     // message fields
     pub key: ::std::vec::Vec<u8>,
@@ -1958,19 +1898,13 @@ impl ::protobuf::Clear for ScanMvccResponse {
     }
 }
 
-impl ::std::fmt::Debug for ScanMvccResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanMvccResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactRequest {
     // message fields
     pub db: DB,
@@ -2255,19 +2189,13 @@ impl ::protobuf::Clear for CompactRequest {
     }
 }
 
-impl ::std::fmt::Debug for CompactRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2358,19 +2286,13 @@ impl ::protobuf::Clear for CompactResponse {
     }
 }
 
-impl ::std::fmt::Debug for CompactResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct InjectFailPointRequest {
     // message fields
     pub name: ::std::string::String,
@@ -2536,19 +2458,13 @@ impl ::protobuf::Clear for InjectFailPointRequest {
     }
 }
 
-impl ::std::fmt::Debug for InjectFailPointRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for InjectFailPointRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct InjectFailPointResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2639,19 +2555,13 @@ impl ::protobuf::Clear for InjectFailPointResponse {
     }
 }
 
-impl ::std::fmt::Debug for InjectFailPointResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for InjectFailPointResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RecoverFailPointRequest {
     // message fields
     pub name: ::std::string::String,
@@ -2780,19 +2690,13 @@ impl ::protobuf::Clear for RecoverFailPointRequest {
     }
 }
 
-impl ::std::fmt::Debug for RecoverFailPointRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RecoverFailPointRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RecoverFailPointResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2883,19 +2787,13 @@ impl ::protobuf::Clear for RecoverFailPointResponse {
     }
 }
 
-impl ::std::fmt::Debug for RecoverFailPointResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RecoverFailPointResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ListFailPointsRequest {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2986,19 +2884,13 @@ impl ::protobuf::Clear for ListFailPointsRequest {
     }
 }
 
-impl ::std::fmt::Debug for ListFailPointsRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ListFailPointsRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ListFailPointsResponse {
     // message fields
     pub entries: ::protobuf::RepeatedField<ListFailPointsResponse_Entry>,
@@ -3134,19 +3026,13 @@ impl ::protobuf::Clear for ListFailPointsResponse {
     }
 }
 
-impl ::std::fmt::Debug for ListFailPointsResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ListFailPointsResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ListFailPointsResponse_Entry {
     // message fields
     pub name: ::std::string::String,
@@ -3312,19 +3198,13 @@ impl ::protobuf::Clear for ListFailPointsResponse_Entry {
     }
 }
 
-impl ::std::fmt::Debug for ListFailPointsResponse_Entry {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ListFailPointsResponse_Entry {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetMetricsRequest {
     // message fields
     pub all: bool,
@@ -3446,19 +3326,13 @@ impl ::protobuf::Clear for GetMetricsRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetMetricsRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetMetricsRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetMetricsResponse {
     // message fields
     pub prometheus: ::std::string::String,
@@ -3728,19 +3602,13 @@ impl ::protobuf::Clear for GetMetricsResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetMetricsResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetMetricsResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionConsistencyCheckRequest {
     // message fields
     pub region_id: u64,
@@ -3862,19 +3730,13 @@ impl ::protobuf::Clear for RegionConsistencyCheckRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionConsistencyCheckRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionConsistencyCheckRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionConsistencyCheckResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -3965,19 +3827,13 @@ impl ::protobuf::Clear for RegionConsistencyCheckResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionConsistencyCheckResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionConsistencyCheckResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ModifyTikvConfigRequest {
     // message fields
     pub module: MODULE,
@@ -4169,19 +4025,13 @@ impl ::protobuf::Clear for ModifyTikvConfigRequest {
     }
 }
 
-impl ::std::fmt::Debug for ModifyTikvConfigRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ModifyTikvConfigRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ModifyTikvConfigResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -4272,19 +4122,13 @@ impl ::protobuf::Clear for ModifyTikvConfigResponse {
     }
 }
 
-impl ::std::fmt::Debug for ModifyTikvConfigResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ModifyTikvConfigResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Property {
     // message fields
     pub name: ::std::string::String,
@@ -4450,19 +4294,13 @@ impl ::protobuf::Clear for Property {
     }
 }
 
-impl ::std::fmt::Debug for Property {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Property {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRegionPropertiesRequest {
     // message fields
     pub region_id: u64,
@@ -4584,19 +4422,13 @@ impl ::protobuf::Clear for GetRegionPropertiesRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRegionPropertiesRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRegionPropertiesRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRegionPropertiesResponse {
     // message fields
     pub props: ::protobuf::RepeatedField<Property>,
@@ -4729,12 +4561,6 @@ impl ::protobuf::Clear for GetRegionPropertiesResponse {
     fn clear(&mut self) {
         self.clear_props();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for GetRegionPropertiesResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/errorpb.rs
+++ b/src/protobuf/errorpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct NotLeader {
     // message fields
     pub region_id: u64,
@@ -195,19 +195,13 @@ impl ::protobuf::Clear for NotLeader {
     }
 }
 
-impl ::std::fmt::Debug for NotLeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for NotLeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreNotMatch {
     // message fields
     pub request_store_id: u64,
@@ -359,19 +353,13 @@ impl ::protobuf::Clear for StoreNotMatch {
     }
 }
 
-impl ::std::fmt::Debug for StoreNotMatch {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreNotMatch {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionNotFound {
     // message fields
     pub region_id: u64,
@@ -493,19 +481,13 @@ impl ::protobuf::Clear for RegionNotFound {
     }
 }
 
-impl ::std::fmt::Debug for RegionNotFound {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionNotFound {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KeyNotInRegion {
     // message fields
     pub key: ::std::vec::Vec<u8>,
@@ -738,19 +720,13 @@ impl ::protobuf::Clear for KeyNotInRegion {
     }
 }
 
-impl ::std::fmt::Debug for KeyNotInRegion {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KeyNotInRegion {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct EpochNotMatch {
     // message fields
     pub current_regions: ::protobuf::RepeatedField<super::metapb::Region>,
@@ -886,19 +862,13 @@ impl ::protobuf::Clear for EpochNotMatch {
     }
 }
 
-impl ::std::fmt::Debug for EpochNotMatch {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for EpochNotMatch {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ServerIsBusy {
     // message fields
     pub reason: ::std::string::String,
@@ -1057,19 +1027,13 @@ impl ::protobuf::Clear for ServerIsBusy {
     }
 }
 
-impl ::std::fmt::Debug for ServerIsBusy {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ServerIsBusy {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StaleCommand {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1160,19 +1124,13 @@ impl ::protobuf::Clear for StaleCommand {
     }
 }
 
-impl ::std::fmt::Debug for StaleCommand {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StaleCommand {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftEntryTooLarge {
     // message fields
     pub region_id: u64,
@@ -1324,19 +1282,13 @@ impl ::protobuf::Clear for RaftEntryTooLarge {
     }
 }
 
-impl ::std::fmt::Debug for RaftEntryTooLarge {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftEntryTooLarge {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Error {
     // message fields
     pub message: ::std::string::String,
@@ -1878,12 +1830,6 @@ impl ::protobuf::Clear for Error {
         self.clear_store_not_match();
         self.clear_raft_entry_too_large();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/import_kvpb.rs
+++ b/src/protobuf/import_kvpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SwitchModeRequest {
     // message fields
     pub pd_addr: ::std::string::String,
@@ -202,19 +202,13 @@ impl ::protobuf::Clear for SwitchModeRequest {
     }
 }
 
-impl ::std::fmt::Debug for SwitchModeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SwitchModeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SwitchModeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -305,19 +299,13 @@ impl ::protobuf::Clear for SwitchModeResponse {
     }
 }
 
-impl ::std::fmt::Debug for SwitchModeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SwitchModeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct OpenEngineRequest {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -446,19 +434,13 @@ impl ::protobuf::Clear for OpenEngineRequest {
     }
 }
 
-impl ::std::fmt::Debug for OpenEngineRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for OpenEngineRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct OpenEngineResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -549,19 +531,13 @@ impl ::protobuf::Clear for OpenEngineResponse {
     }
 }
 
-impl ::std::fmt::Debug for OpenEngineResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for OpenEngineResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct WriteHead {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -690,19 +666,13 @@ impl ::protobuf::Clear for WriteHead {
     }
 }
 
-impl ::std::fmt::Debug for WriteHead {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for WriteHead {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Mutation {
     // message fields
     pub op: Mutation_OP,
@@ -894,12 +864,6 @@ impl ::protobuf::Clear for Mutation {
     }
 }
 
-impl ::std::fmt::Debug for Mutation {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Mutation {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
@@ -946,7 +910,7 @@ impl ::protobuf::reflect::ProtobufValue for Mutation_OP {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct WriteBatch {
     // message fields
     pub commit_ts: u64,
@@ -1112,19 +1076,13 @@ impl ::protobuf::Clear for WriteBatch {
     }
 }
 
-impl ::std::fmt::Debug for WriteBatch {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for WriteBatch {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct WriteEngineRequest {
     // message oneof groups
     pub chunk: ::std::option::Option<WriteEngineRequest_oneof_chunk>,
@@ -1133,7 +1091,7 @@ pub struct WriteEngineRequest {
     cached_size: ::protobuf::CachedSize,
 }
 
-#[derive(Clone,PartialEq)]
+#[derive(Clone,PartialEq,Debug)]
 pub enum WriteEngineRequest_oneof_chunk {
     head(WriteHead),
     batch(WriteBatch),
@@ -1371,19 +1329,13 @@ impl ::protobuf::Clear for WriteEngineRequest {
     }
 }
 
-impl ::std::fmt::Debug for WriteEngineRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for WriteEngineRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct WriteEngineResponse {
     // message fields
     pub error: ::protobuf::SingularPtrField<Error>,
@@ -1527,19 +1479,13 @@ impl ::protobuf::Clear for WriteEngineResponse {
     }
 }
 
-impl ::std::fmt::Debug for WriteEngineResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for WriteEngineResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CloseEngineRequest {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -1668,19 +1614,13 @@ impl ::protobuf::Clear for CloseEngineRequest {
     }
 }
 
-impl ::std::fmt::Debug for CloseEngineRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CloseEngineRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CloseEngineResponse {
     // message fields
     pub error: ::protobuf::SingularPtrField<Error>,
@@ -1824,19 +1764,13 @@ impl ::protobuf::Clear for CloseEngineResponse {
     }
 }
 
-impl ::std::fmt::Debug for CloseEngineResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CloseEngineResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ImportEngineRequest {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -2002,19 +1936,13 @@ impl ::protobuf::Clear for ImportEngineRequest {
     }
 }
 
-impl ::std::fmt::Debug for ImportEngineRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ImportEngineRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ImportEngineResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2105,19 +2033,13 @@ impl ::protobuf::Clear for ImportEngineResponse {
     }
 }
 
-impl ::std::fmt::Debug for ImportEngineResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ImportEngineResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CleanupEngineRequest {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -2246,19 +2168,13 @@ impl ::protobuf::Clear for CleanupEngineRequest {
     }
 }
 
-impl ::std::fmt::Debug for CleanupEngineRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CleanupEngineRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CleanupEngineResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2349,19 +2265,13 @@ impl ::protobuf::Clear for CleanupEngineResponse {
     }
 }
 
-impl ::std::fmt::Debug for CleanupEngineResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CleanupEngineResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactClusterRequest {
     // message fields
     pub pd_addr: ::std::string::String,
@@ -2542,19 +2452,13 @@ impl ::protobuf::Clear for CompactClusterRequest {
     }
 }
 
-impl ::std::fmt::Debug for CompactClusterRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactClusterRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactClusterResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2645,19 +2549,13 @@ impl ::protobuf::Clear for CompactClusterResponse {
     }
 }
 
-impl ::std::fmt::Debug for CompactClusterResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactClusterResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Error {
     // message fields
     pub engine_not_found: ::protobuf::SingularPtrField<Error_EngineNotFound>,
@@ -2801,19 +2699,13 @@ impl ::protobuf::Clear for Error {
     }
 }
 
-impl ::std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Error {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Error_EngineNotFound {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -2939,12 +2831,6 @@ impl ::protobuf::Clear for Error_EngineNotFound {
     fn clear(&mut self) {
         self.clear_uuid();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for Error_EngineNotFound {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/import_sstpb.rs
+++ b/src/protobuf/import_sstpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SwitchModeRequest {
     // message fields
     pub mode: SwitchMode,
@@ -139,19 +139,13 @@ impl ::protobuf::Clear for SwitchModeRequest {
     }
 }
 
-impl ::std::fmt::Debug for SwitchModeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SwitchModeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SwitchModeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -242,19 +236,13 @@ impl ::protobuf::Clear for SwitchModeResponse {
     }
 }
 
-impl ::std::fmt::Debug for SwitchModeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SwitchModeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Range {
     // message fields
     pub start: ::std::vec::Vec<u8>,
@@ -420,19 +408,13 @@ impl ::protobuf::Clear for Range {
     }
 }
 
-impl ::std::fmt::Debug for Range {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Range {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SSTMeta {
     // message fields
     pub uuid: ::std::vec::Vec<u8>,
@@ -792,19 +774,13 @@ impl ::protobuf::Clear for SSTMeta {
     }
 }
 
-impl ::std::fmt::Debug for SSTMeta {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SSTMeta {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UploadRequest {
     // message oneof groups
     pub chunk: ::std::option::Option<UploadRequest_oneof_chunk>,
@@ -813,7 +789,7 @@ pub struct UploadRequest {
     cached_size: ::protobuf::CachedSize,
 }
 
-#[derive(Clone,PartialEq)]
+#[derive(Clone,PartialEq,Debug)]
 pub enum UploadRequest_oneof_chunk {
     meta(SSTMeta),
     data(::std::vec::Vec<u8>),
@@ -1043,19 +1019,13 @@ impl ::protobuf::Clear for UploadRequest {
     }
 }
 
-impl ::std::fmt::Debug for UploadRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for UploadRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UploadResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1146,19 +1116,13 @@ impl ::protobuf::Clear for UploadResponse {
     }
 }
 
-impl ::std::fmt::Debug for UploadResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for UploadResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IngestRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<super::kvrpcpb::Context>,
@@ -1354,19 +1318,13 @@ impl ::protobuf::Clear for IngestRequest {
     }
 }
 
-impl ::std::fmt::Debug for IngestRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IngestRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IngestResponse {
     // message fields
     pub error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -1510,19 +1468,13 @@ impl ::protobuf::Clear for IngestResponse {
     }
 }
 
-impl ::std::fmt::Debug for IngestResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IngestResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactRequest {
     // message fields
     pub range: ::protobuf::SingularPtrField<Range>,
@@ -1696,19 +1648,13 @@ impl ::protobuf::Clear for CompactRequest {
     }
 }
 
-impl ::std::fmt::Debug for CompactRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1796,12 +1742,6 @@ impl ::protobuf::Message for CompactResponse {
 impl ::protobuf::Clear for CompactResponse {
     fn clear(&mut self) {
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for CompactResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/kvrpcpb.rs
+++ b/src/protobuf/kvrpcpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct LockInfo {
     // message fields
     pub primary_lock: ::std::vec::Vec<u8>,
@@ -247,19 +247,13 @@ impl ::protobuf::Clear for LockInfo {
     }
 }
 
-impl ::std::fmt::Debug for LockInfo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for LockInfo {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AlreadyExist {
     // message fields
     pub key: ::std::vec::Vec<u8>,
@@ -388,19 +382,13 @@ impl ::protobuf::Clear for AlreadyExist {
     }
 }
 
-impl ::std::fmt::Debug for AlreadyExist {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AlreadyExist {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KeyError {
     // message fields
     pub locked: ::protobuf::SingularPtrField<LockInfo>,
@@ -722,19 +710,13 @@ impl ::protobuf::Clear for KeyError {
     }
 }
 
-impl ::std::fmt::Debug for KeyError {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KeyError {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct WriteConflict {
     // message fields
     pub start_ts: u64,
@@ -960,19 +942,13 @@ impl ::protobuf::Clear for WriteConflict {
     }
 }
 
-impl ::std::fmt::Debug for WriteConflict {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for WriteConflict {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Context {
     // message fields
     pub region_id: u64,
@@ -1400,19 +1376,13 @@ impl ::protobuf::Clear for Context {
     }
 }
 
-impl ::std::fmt::Debug for Context {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Context {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct HandleTime {
     // message fields
     pub wait_ms: i64,
@@ -1564,19 +1534,13 @@ impl ::protobuf::Clear for HandleTime {
     }
 }
 
-impl ::std::fmt::Debug for HandleTime {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for HandleTime {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanInfo {
     // message fields
     pub total: i64,
@@ -1728,19 +1692,13 @@ impl ::protobuf::Clear for ScanInfo {
     }
 }
 
-impl ::std::fmt::Debug for ScanInfo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanInfo {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanDetail {
     // message fields
     pub write: ::protobuf::SingularPtrField<ScanInfo>,
@@ -1988,19 +1946,13 @@ impl ::protobuf::Clear for ScanDetail {
     }
 }
 
-impl ::std::fmt::Debug for ScanDetail {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanDetail {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ExecDetails {
     // message fields
     pub handle_time: ::protobuf::SingularPtrField<HandleTime>,
@@ -2196,19 +2148,13 @@ impl ::protobuf::Clear for ExecDetails {
     }
 }
 
-impl ::std::fmt::Debug for ExecDetails {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ExecDetails {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -2419,19 +2365,13 @@ impl ::protobuf::Clear for GetRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -2664,19 +2604,13 @@ impl ::protobuf::Clear for GetResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -3014,19 +2948,13 @@ impl ::protobuf::Clear for ScanRequest {
     }
 }
 
-impl ::std::fmt::Debug for ScanRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KvPair {
     // message fields
     pub error: ::protobuf::SingularPtrField<KeyError>,
@@ -3244,19 +3172,13 @@ impl ::protobuf::Clear for KvPair {
     }
 }
 
-impl ::std::fmt::Debug for KvPair {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KvPair {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -3444,19 +3366,13 @@ impl ::protobuf::Clear for ScanResponse {
     }
 }
 
-impl ::std::fmt::Debug for ScanResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Mutation {
     // message fields
     pub op: Op,
@@ -3674,19 +3590,13 @@ impl ::protobuf::Clear for Mutation {
     }
 }
 
-impl ::std::fmt::Debug for Mutation {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Mutation {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrewriteRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -4001,19 +3911,13 @@ impl ::protobuf::Clear for PrewriteRequest {
     }
 }
 
-impl ::std::fmt::Debug for PrewriteRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrewriteRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrewriteResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -4201,19 +4105,13 @@ impl ::protobuf::Clear for PrewriteResponse {
     }
 }
 
-impl ::std::fmt::Debug for PrewriteResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrewriteResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CommitRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -4453,19 +4351,13 @@ impl ::protobuf::Clear for CommitRequest {
     }
 }
 
-impl ::std::fmt::Debug for CommitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CommitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CommitResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -4661,19 +4553,13 @@ impl ::protobuf::Clear for CommitResponse {
     }
 }
 
-impl ::std::fmt::Debug for CommitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CommitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ImportRequest {
     // message fields
     pub mutations: ::protobuf::RepeatedField<Mutation>,
@@ -4839,19 +4725,13 @@ impl ::protobuf::Clear for ImportRequest {
     }
 }
 
-impl ::std::fmt::Debug for ImportRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ImportRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ImportResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -5032,19 +4912,13 @@ impl ::protobuf::Clear for ImportResponse {
     }
 }
 
-impl ::std::fmt::Debug for ImportResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ImportResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchRollbackRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -5254,19 +5128,13 @@ impl ::protobuf::Clear for BatchRollbackRequest {
     }
 }
 
-impl ::std::fmt::Debug for BatchRollbackRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchRollbackRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchRollbackResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -5462,19 +5330,13 @@ impl ::protobuf::Clear for BatchRollbackResponse {
     }
 }
 
-impl ::std::fmt::Debug for BatchRollbackResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchRollbackResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CleanupRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -5685,19 +5547,13 @@ impl ::protobuf::Clear for CleanupRequest {
     }
 }
 
-impl ::std::fmt::Debug for CleanupRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CleanupRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CleanupResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -5923,19 +5779,13 @@ impl ::protobuf::Clear for CleanupResponse {
     }
 }
 
-impl ::std::fmt::Debug for CleanupResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CleanupResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchGetRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -6145,19 +5995,13 @@ impl ::protobuf::Clear for BatchGetRequest {
     }
 }
 
-impl ::std::fmt::Debug for BatchGetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchGetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchGetResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -6345,19 +6189,13 @@ impl ::protobuf::Clear for BatchGetResponse {
     }
 }
 
-impl ::std::fmt::Debug for BatchGetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchGetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanLockRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -6598,19 +6436,13 @@ impl ::protobuf::Clear for ScanLockRequest {
     }
 }
 
-impl ::std::fmt::Debug for ScanLockRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanLockRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScanLockResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -6850,19 +6682,13 @@ impl ::protobuf::Clear for ScanLockResponse {
     }
 }
 
-impl ::std::fmt::Debug for ScanLockResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScanLockResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TxnInfo {
     // message fields
     pub txn: u64,
@@ -7014,19 +6840,13 @@ impl ::protobuf::Clear for TxnInfo {
     }
 }
 
-impl ::std::fmt::Debug for TxnInfo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TxnInfo {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ResolveLockRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -7274,19 +7094,13 @@ impl ::protobuf::Clear for ResolveLockRequest {
     }
 }
 
-impl ::std::fmt::Debug for ResolveLockRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ResolveLockRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ResolveLockResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -7482,19 +7296,13 @@ impl ::protobuf::Clear for ResolveLockResponse {
     }
 }
 
-impl ::std::fmt::Debug for ResolveLockResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ResolveLockResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GCRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -7668,19 +7476,13 @@ impl ::protobuf::Clear for GCRequest {
     }
 }
 
-impl ::std::fmt::Debug for GCRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GCRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GCResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -7876,19 +7678,13 @@ impl ::protobuf::Clear for GCResponse {
     }
 }
 
-impl ::std::fmt::Debug for GCResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GCResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawGetRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -8106,19 +7902,13 @@ impl ::protobuf::Clear for RawGetRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawGetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawGetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawGetResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -8336,19 +8126,13 @@ impl ::protobuf::Clear for RawGetResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawGetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawGetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawPutRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -8603,19 +8387,13 @@ impl ::protobuf::Clear for RawPutRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawPutRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawPutRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawPutResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -8796,19 +8574,13 @@ impl ::protobuf::Clear for RawPutResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawPutResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawPutResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchPutRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -9033,19 +8805,13 @@ impl ::protobuf::Clear for RawBatchPutRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchPutRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchPutRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchPutResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -9226,19 +8992,13 @@ impl ::protobuf::Clear for RawBatchPutResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchPutResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchPutResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchGetRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -9455,19 +9215,13 @@ impl ::protobuf::Clear for RawBatchGetRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchGetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchGetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchGetResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -9655,19 +9409,13 @@ impl ::protobuf::Clear for RawBatchGetResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchGetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchGetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawDeleteRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -9885,19 +9633,13 @@ impl ::protobuf::Clear for RawDeleteRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawDeleteRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawDeleteRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawDeleteResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -10078,19 +9820,13 @@ impl ::protobuf::Clear for RawDeleteResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawDeleteResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawDeleteResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchDeleteRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -10307,19 +10043,13 @@ impl ::protobuf::Clear for RawBatchDeleteRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchDeleteRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchDeleteRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchDeleteResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -10500,19 +10230,13 @@ impl ::protobuf::Clear for RawBatchDeleteResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchDeleteResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchDeleteResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteRangeRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -10730,19 +10454,13 @@ impl ::protobuf::Clear for DeleteRangeRequest {
     }
 }
 
-impl ::std::fmt::Debug for DeleteRangeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteRangeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteRangeResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -10923,19 +10641,13 @@ impl ::protobuf::Clear for DeleteRangeResponse {
     }
 }
 
-impl ::std::fmt::Debug for DeleteRangeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteRangeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawDeleteRangeRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -11190,19 +10902,13 @@ impl ::protobuf::Clear for RawDeleteRangeRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawDeleteRangeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawDeleteRangeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawDeleteRangeResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -11383,19 +11089,13 @@ impl ::protobuf::Clear for RawDeleteRangeResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawDeleteRangeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawDeleteRangeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawScanRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -11740,19 +11440,13 @@ impl ::protobuf::Clear for RawScanRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawScanRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawScanRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawScanResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -11940,19 +11634,13 @@ impl ::protobuf::Clear for RawScanResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawScanResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawScanResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KeyRange {
     // message fields
     pub start_key: ::std::vec::Vec<u8>,
@@ -12118,19 +11806,13 @@ impl ::protobuf::Clear for KeyRange {
     }
 }
 
-impl ::std::fmt::Debug for KeyRange {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KeyRange {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchScanRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -12445,19 +12127,13 @@ impl ::protobuf::Clear for RawBatchScanRequest {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchScanRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchScanRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RawBatchScanResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -12645,19 +12321,13 @@ impl ::protobuf::Clear for RawBatchScanResponse {
     }
 }
 
-impl ::std::fmt::Debug for RawBatchScanResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RawBatchScanResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccWrite {
     // message fields
     pub field_type: Op,
@@ -12872,19 +12542,13 @@ impl ::protobuf::Clear for MvccWrite {
     }
 }
 
-impl ::std::fmt::Debug for MvccWrite {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccWrite {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccValue {
     // message fields
     pub start_ts: u64,
@@ -13043,19 +12707,13 @@ impl ::protobuf::Clear for MvccValue {
     }
 }
 
-impl ::std::fmt::Debug for MvccValue {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccValue {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccLock {
     // message fields
     pub field_type: Op,
@@ -13277,19 +12935,13 @@ impl ::protobuf::Clear for MvccLock {
     }
 }
 
-impl ::std::fmt::Debug for MvccLock {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccLock {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccInfo {
     // message fields
     pub lock: ::protobuf::SingularPtrField<MvccLock>,
@@ -13521,19 +13173,13 @@ impl ::protobuf::Clear for MvccInfo {
     }
 }
 
-impl ::std::fmt::Debug for MvccInfo {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccInfo {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccGetByKeyRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -13714,19 +13360,13 @@ impl ::protobuf::Clear for MvccGetByKeyRequest {
     }
 }
 
-impl ::std::fmt::Debug for MvccGetByKeyRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccGetByKeyRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccGetByKeyResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -13959,19 +13599,13 @@ impl ::protobuf::Clear for MvccGetByKeyResponse {
     }
 }
 
-impl ::std::fmt::Debug for MvccGetByKeyResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccGetByKeyResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccGetByStartTsRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -14145,19 +13779,13 @@ impl ::protobuf::Clear for MvccGetByStartTsRequest {
     }
 }
 
-impl ::std::fmt::Debug for MvccGetByStartTsRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccGetByStartTsRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MvccGetByStartTsResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -14427,19 +14055,13 @@ impl ::protobuf::Clear for MvccGetByStartTsResponse {
     }
 }
 
-impl ::std::fmt::Debug for MvccGetByStartTsResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MvccGetByStartTsResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitRegionRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -14620,19 +14242,13 @@ impl ::protobuf::Clear for SplitRegionRequest {
     }
 }
 
-impl ::std::fmt::Debug for SplitRegionRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitRegionRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitRegionResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -14880,19 +14496,13 @@ impl ::protobuf::Clear for SplitRegionResponse {
     }
 }
 
-impl ::std::fmt::Debug for SplitRegionResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitRegionResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UnsafeDestroyRangeRequest {
     // message fields
     pub context: ::protobuf::SingularPtrField<Context>,
@@ -15110,19 +14720,13 @@ impl ::protobuf::Clear for UnsafeDestroyRangeRequest {
     }
 }
 
-impl ::std::fmt::Debug for UnsafeDestroyRangeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for UnsafeDestroyRangeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UnsafeDestroyRangeResponse {
     // message fields
     pub region_error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -15300,12 +14904,6 @@ impl ::protobuf::Clear for UnsafeDestroyRangeResponse {
         self.clear_region_error();
         self.clear_error();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for UnsafeDestroyRangeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/metapb.rs
+++ b/src/protobuf/metapb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Cluster {
     // message fields
     pub id: u64,
@@ -173,19 +173,13 @@ impl ::protobuf::Clear for Cluster {
     }
 }
 
-impl ::std::fmt::Debug for Cluster {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Cluster {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreLabel {
     // message fields
     pub key: ::std::string::String,
@@ -351,19 +345,13 @@ impl ::protobuf::Clear for StoreLabel {
     }
 }
 
-impl ::std::fmt::Debug for StoreLabel {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreLabel {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Store {
     // message fields
     pub id: u64,
@@ -629,19 +617,13 @@ impl ::protobuf::Clear for Store {
     }
 }
 
-impl ::std::fmt::Debug for Store {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Store {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionEpoch {
     // message fields
     pub conf_ver: u64,
@@ -793,19 +775,13 @@ impl ::protobuf::Clear for RegionEpoch {
     }
 }
 
-impl ::std::fmt::Debug for RegionEpoch {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionEpoch {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Region {
     // message fields
     pub id: u64,
@@ -1097,19 +1073,13 @@ impl ::protobuf::Clear for Region {
     }
 }
 
-impl ::std::fmt::Debug for Region {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Region {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Peer {
     // message fields
     pub id: u64,
@@ -1288,12 +1258,6 @@ impl ::protobuf::Clear for Peer {
         self.clear_store_id();
         self.clear_is_learner();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for Peer {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/pdpb.rs
+++ b/src/protobuf/pdpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RequestHeader {
     // message fields
     pub cluster_id: u64,
@@ -143,19 +143,13 @@ impl ::protobuf::Clear for RequestHeader {
     }
 }
 
-impl ::std::fmt::Debug for RequestHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RequestHeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ResponseHeader {
     // message fields
     pub cluster_id: u64,
@@ -329,19 +323,13 @@ impl ::protobuf::Clear for ResponseHeader {
     }
 }
 
-impl ::std::fmt::Debug for ResponseHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ResponseHeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Error {
     // message fields
     pub field_type: ErrorType,
@@ -496,19 +484,13 @@ impl ::protobuf::Clear for Error {
     }
 }
 
-impl ::std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Error {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TsoRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -682,19 +664,13 @@ impl ::protobuf::Clear for TsoRequest {
     }
 }
 
-impl ::std::fmt::Debug for TsoRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TsoRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Timestamp {
     // message fields
     pub physical: i64,
@@ -846,19 +822,13 @@ impl ::protobuf::Clear for Timestamp {
     }
 }
 
-impl ::std::fmt::Debug for Timestamp {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Timestamp {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TsoResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -1084,19 +1054,13 @@ impl ::protobuf::Clear for TsoResponse {
     }
 }
 
-impl ::std::fmt::Debug for TsoResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TsoResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BootstrapRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -1344,19 +1308,13 @@ impl ::protobuf::Clear for BootstrapRequest {
     }
 }
 
-impl ::std::fmt::Debug for BootstrapRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BootstrapRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BootstrapResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -1500,19 +1458,13 @@ impl ::protobuf::Clear for BootstrapResponse {
     }
 }
 
-impl ::std::fmt::Debug for BootstrapResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BootstrapResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IsBootstrappedRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -1656,19 +1608,13 @@ impl ::protobuf::Clear for IsBootstrappedRequest {
     }
 }
 
-impl ::std::fmt::Debug for IsBootstrappedRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IsBootstrappedRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IsBootstrappedResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -1842,19 +1788,13 @@ impl ::protobuf::Clear for IsBootstrappedResponse {
     }
 }
 
-impl ::std::fmt::Debug for IsBootstrappedResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IsBootstrappedResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AllocIDRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -1998,19 +1938,13 @@ impl ::protobuf::Clear for AllocIDRequest {
     }
 }
 
-impl ::std::fmt::Debug for AllocIDRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AllocIDRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AllocIDResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -2184,19 +2118,13 @@ impl ::protobuf::Clear for AllocIDResponse {
     }
 }
 
-impl ::std::fmt::Debug for AllocIDResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AllocIDResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetStoreRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -2370,19 +2298,13 @@ impl ::protobuf::Clear for GetStoreRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetStoreRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetStoreRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetStoreResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -2630,19 +2552,13 @@ impl ::protobuf::Clear for GetStoreResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetStoreResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetStoreResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutStoreRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -2838,19 +2754,13 @@ impl ::protobuf::Clear for PutStoreRequest {
     }
 }
 
-impl ::std::fmt::Debug for PutStoreRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutStoreRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutStoreResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -2994,19 +2904,13 @@ impl ::protobuf::Clear for PutStoreResponse {
     }
 }
 
-impl ::std::fmt::Debug for PutStoreResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutStoreResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetAllStoresRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -3180,19 +3084,13 @@ impl ::protobuf::Clear for GetAllStoresRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetAllStoresRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetAllStoresRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetAllStoresResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -3380,19 +3278,13 @@ impl ::protobuf::Clear for GetAllStoresResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetAllStoresResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetAllStoresResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRegionRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -3573,19 +3465,13 @@ impl ::protobuf::Clear for GetRegionRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRegionRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRegionRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRegionResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -3833,19 +3719,13 @@ impl ::protobuf::Clear for GetRegionResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetRegionResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRegionResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRegionByIDRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -4019,19 +3899,13 @@ impl ::protobuf::Clear for GetRegionByIDRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRegionByIDRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRegionByIDRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetClusterConfigRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -4175,19 +4049,13 @@ impl ::protobuf::Clear for GetClusterConfigRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetClusterConfigRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetClusterConfigRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetClusterConfigResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -4383,19 +4251,13 @@ impl ::protobuf::Clear for GetClusterConfigResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetClusterConfigResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetClusterConfigResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutClusterConfigRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -4591,19 +4453,13 @@ impl ::protobuf::Clear for PutClusterConfigRequest {
     }
 }
 
-impl ::std::fmt::Debug for PutClusterConfigRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutClusterConfigRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutClusterConfigResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -4747,19 +4603,13 @@ impl ::protobuf::Clear for PutClusterConfigResponse {
     }
 }
 
-impl ::std::fmt::Debug for PutClusterConfigResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutClusterConfigResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Member {
     // message fields
     pub name: ::std::string::String,
@@ -5020,19 +4870,13 @@ impl ::protobuf::Clear for Member {
     }
 }
 
-impl ::std::fmt::Debug for Member {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Member {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetMembersRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -5176,19 +5020,13 @@ impl ::protobuf::Clear for GetMembersRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetMembersRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetMembersRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetMembersResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -5480,19 +5318,13 @@ impl ::protobuf::Clear for GetMembersResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetMembersResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetMembersResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PeerStats {
     // message fields
     pub peer: ::protobuf::SingularPtrField<super::metapb::Peer>,
@@ -5666,19 +5498,13 @@ impl ::protobuf::Clear for PeerStats {
     }
 }
 
-impl ::std::fmt::Debug for PeerStats {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PeerStats {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionHeartbeatRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -6246,19 +6072,13 @@ impl ::protobuf::Clear for RegionHeartbeatRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionHeartbeatRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionHeartbeatRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ChangePeer {
     // message fields
     pub peer: ::protobuf::SingularPtrField<super::metapb::Peer>,
@@ -6428,19 +6248,13 @@ impl ::protobuf::Clear for ChangePeer {
     }
 }
 
-impl ::std::fmt::Debug for ChangePeer {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ChangePeer {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TransferLeader {
     // message fields
     pub peer: ::protobuf::SingularPtrField<super::metapb::Peer>,
@@ -6584,19 +6398,13 @@ impl ::protobuf::Clear for TransferLeader {
     }
 }
 
-impl ::std::fmt::Debug for TransferLeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TransferLeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Merge {
     // message fields
     pub target: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -6740,19 +6548,13 @@ impl ::protobuf::Clear for Merge {
     }
 }
 
-impl ::std::fmt::Debug for Merge {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Merge {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitRegion {
     // message fields
     pub policy: CheckPolicy,
@@ -6870,19 +6672,13 @@ impl ::protobuf::Clear for SplitRegion {
     }
 }
 
-impl ::std::fmt::Debug for SplitRegion {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitRegion {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionHeartbeatResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -7368,19 +7164,13 @@ impl ::protobuf::Clear for RegionHeartbeatResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionHeartbeatResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionHeartbeatResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AskSplitRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -7576,19 +7366,13 @@ impl ::protobuf::Clear for AskSplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for AskSplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AskSplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AskSplitResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -7798,19 +7582,13 @@ impl ::protobuf::Clear for AskSplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for AskSplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AskSplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ReportSplitRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -8058,19 +7836,13 @@ impl ::protobuf::Clear for ReportSplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for ReportSplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ReportSplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ReportSplitResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -8214,19 +7986,13 @@ impl ::protobuf::Clear for ReportSplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for ReportSplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ReportSplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AskBatchSplitRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -8452,19 +8218,13 @@ impl ::protobuf::Clear for AskBatchSplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for AskBatchSplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AskBatchSplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitID {
     // message fields
     pub new_region_id: u64,
@@ -8622,19 +8382,13 @@ impl ::protobuf::Clear for SplitID {
     }
 }
 
-impl ::std::fmt::Debug for SplitID {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitID {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AskBatchSplitResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -8822,19 +8576,13 @@ impl ::protobuf::Clear for AskBatchSplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for AskBatchSplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AskBatchSplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ReportBatchSplitRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -9022,19 +8770,13 @@ impl ::protobuf::Clear for ReportBatchSplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for ReportBatchSplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ReportBatchSplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ReportBatchSplitResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -9178,19 +8920,13 @@ impl ::protobuf::Clear for ReportBatchSplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for ReportBatchSplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ReportBatchSplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TimeInterval {
     // message fields
     pub start_timestamp: u64,
@@ -9342,19 +9078,13 @@ impl ::protobuf::Clear for TimeInterval {
     }
 }
 
-impl ::std::fmt::Debug for TimeInterval {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TimeInterval {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreStats {
     // message fields
     pub store_id: u64,
@@ -9918,19 +9648,13 @@ impl ::protobuf::Clear for StoreStats {
     }
 }
 
-impl ::std::fmt::Debug for StoreStats {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreStats {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreHeartbeatRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -10126,19 +9850,13 @@ impl ::protobuf::Clear for StoreHeartbeatRequest {
     }
 }
 
-impl ::std::fmt::Debug for StoreHeartbeatRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreHeartbeatRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreHeartbeatResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -10282,19 +10000,13 @@ impl ::protobuf::Clear for StoreHeartbeatResponse {
     }
 }
 
-impl ::std::fmt::Debug for StoreHeartbeatResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreHeartbeatResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScatterRegionRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -10572,19 +10284,13 @@ impl ::protobuf::Clear for ScatterRegionRequest {
     }
 }
 
-impl ::std::fmt::Debug for ScatterRegionRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScatterRegionRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ScatterRegionResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -10728,19 +10434,13 @@ impl ::protobuf::Clear for ScatterRegionResponse {
     }
 }
 
-impl ::std::fmt::Debug for ScatterRegionResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ScatterRegionResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetGCSafePointRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -10884,19 +10584,13 @@ impl ::protobuf::Clear for GetGCSafePointRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetGCSafePointRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetGCSafePointRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetGCSafePointResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -11070,19 +10764,13 @@ impl ::protobuf::Clear for GetGCSafePointResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetGCSafePointResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetGCSafePointResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UpdateGCSafePointRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -11256,19 +10944,13 @@ impl ::protobuf::Clear for UpdateGCSafePointRequest {
     }
 }
 
-impl ::std::fmt::Debug for UpdateGCSafePointRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for UpdateGCSafePointRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct UpdateGCSafePointResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -11442,19 +11124,13 @@ impl ::protobuf::Clear for UpdateGCSafePointResponse {
     }
 }
 
-impl ::std::fmt::Debug for UpdateGCSafePointResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for UpdateGCSafePointResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SyncRegionRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -11680,19 +11356,13 @@ impl ::protobuf::Clear for SyncRegionRequest {
     }
 }
 
-impl ::std::fmt::Debug for SyncRegionRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SyncRegionRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SyncRegionResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -11910,19 +11580,13 @@ impl ::protobuf::Clear for SyncRegionResponse {
     }
 }
 
-impl ::std::fmt::Debug for SyncRegionResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SyncRegionResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetOperatorRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RequestHeader>,
@@ -12096,19 +11760,13 @@ impl ::protobuf::Clear for GetOperatorRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetOperatorRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetOperatorRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetOperatorResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<ResponseHeader>,
@@ -12379,12 +12037,6 @@ impl ::protobuf::Clear for GetOperatorResponse {
         self.clear_status();
         self.clear_kind();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for GetOperatorResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/raft_cmdpb.rs
+++ b/src/protobuf/raft_cmdpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetRequest {
     // message fields
     pub cf: ::std::string::String,
@@ -187,19 +187,13 @@ impl ::protobuf::Clear for GetRequest {
     }
 }
 
-impl ::std::fmt::Debug for GetRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct GetResponse {
     // message fields
     pub value: ::std::vec::Vec<u8>,
@@ -328,19 +322,13 @@ impl ::protobuf::Clear for GetResponse {
     }
 }
 
-impl ::std::fmt::Debug for GetResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for GetResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutRequest {
     // message fields
     pub cf: ::std::string::String,
@@ -543,19 +531,13 @@ impl ::protobuf::Clear for PutRequest {
     }
 }
 
-impl ::std::fmt::Debug for PutRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PutResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -646,19 +628,13 @@ impl ::protobuf::Clear for PutResponse {
     }
 }
 
-impl ::std::fmt::Debug for PutResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PutResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteRequest {
     // message fields
     pub cf: ::std::string::String,
@@ -824,19 +800,13 @@ impl ::protobuf::Clear for DeleteRequest {
     }
 }
 
-impl ::std::fmt::Debug for DeleteRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -927,19 +897,13 @@ impl ::protobuf::Clear for DeleteResponse {
     }
 }
 
-impl ::std::fmt::Debug for DeleteResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteRangeRequest {
     // message fields
     pub cf: ::std::string::String,
@@ -1142,19 +1106,13 @@ impl ::protobuf::Clear for DeleteRangeRequest {
     }
 }
 
-impl ::std::fmt::Debug for DeleteRangeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteRangeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct DeleteRangeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1245,19 +1203,13 @@ impl ::protobuf::Clear for DeleteRangeResponse {
     }
 }
 
-impl ::std::fmt::Debug for DeleteRangeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for DeleteRangeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SnapRequest {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1348,19 +1300,13 @@ impl ::protobuf::Clear for SnapRequest {
     }
 }
 
-impl ::std::fmt::Debug for SnapRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SnapRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SnapResponse {
     // message fields
     pub region: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -1504,19 +1450,13 @@ impl ::protobuf::Clear for SnapResponse {
     }
 }
 
-impl ::std::fmt::Debug for SnapResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SnapResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrewriteRequest {
     // message fields
     pub key: ::std::vec::Vec<u8>,
@@ -1719,19 +1659,13 @@ impl ::protobuf::Clear for PrewriteRequest {
     }
 }
 
-impl ::std::fmt::Debug for PrewriteRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrewriteRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrewriteResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1822,19 +1756,13 @@ impl ::protobuf::Clear for PrewriteResponse {
     }
 }
 
-impl ::std::fmt::Debug for PrewriteResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrewriteResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IngestSSTRequest {
     // message fields
     pub sst: ::protobuf::SingularPtrField<super::import_sstpb::SSTMeta>,
@@ -1978,19 +1906,13 @@ impl ::protobuf::Clear for IngestSSTRequest {
     }
 }
 
-impl ::std::fmt::Debug for IngestSSTRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IngestSSTRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct IngestSSTResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -2081,19 +2003,13 @@ impl ::protobuf::Clear for IngestSSTResponse {
     }
 }
 
-impl ::std::fmt::Debug for IngestSSTResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for IngestSSTResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Request {
     // message fields
     pub cmd_type: CmdType,
@@ -2575,19 +2491,13 @@ impl ::protobuf::Clear for Request {
     }
 }
 
-impl ::std::fmt::Debug for Request {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Request {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Response {
     // message fields
     pub cmd_type: CmdType,
@@ -3069,19 +2979,13 @@ impl ::protobuf::Clear for Response {
     }
 }
 
-impl ::std::fmt::Debug for Response {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Response {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ChangePeerRequest {
     // message fields
     pub change_type: super::eraftpb::ConfChangeType,
@@ -3251,19 +3155,13 @@ impl ::protobuf::Clear for ChangePeerRequest {
     }
 }
 
-impl ::std::fmt::Debug for ChangePeerRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ChangePeerRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct ChangePeerResponse {
     // message fields
     pub region: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -3407,19 +3305,13 @@ impl ::protobuf::Clear for ChangePeerResponse {
     }
 }
 
-impl ::std::fmt::Debug for ChangePeerResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for ChangePeerResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitRequest {
     // message fields
     pub split_key: ::std::vec::Vec<u8>,
@@ -3644,19 +3536,13 @@ impl ::protobuf::Clear for SplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for SplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SplitResponse {
     // message fields
     pub left: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -3852,19 +3738,13 @@ impl ::protobuf::Clear for SplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for SplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchSplitRequest {
     // message fields
     pub requests: ::protobuf::RepeatedField<SplitRequest>,
@@ -4030,19 +3910,13 @@ impl ::protobuf::Clear for BatchSplitRequest {
     }
 }
 
-impl ::std::fmt::Debug for BatchSplitRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchSplitRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchSplitResponse {
     // message fields
     pub regions: ::protobuf::RepeatedField<super::metapb::Region>,
@@ -4178,19 +4052,13 @@ impl ::protobuf::Clear for BatchSplitResponse {
     }
 }
 
-impl ::std::fmt::Debug for BatchSplitResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchSplitResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactLogRequest {
     // message fields
     pub compact_index: u64,
@@ -4342,19 +4210,13 @@ impl ::protobuf::Clear for CompactLogRequest {
     }
 }
 
-impl ::std::fmt::Debug for CompactLogRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactLogRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CompactLogResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -4445,19 +4307,13 @@ impl ::protobuf::Clear for CompactLogResponse {
     }
 }
 
-impl ::std::fmt::Debug for CompactLogResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CompactLogResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TransferLeaderRequest {
     // message fields
     pub peer: ::protobuf::SingularPtrField<super::metapb::Peer>,
@@ -4601,19 +4457,13 @@ impl ::protobuf::Clear for TransferLeaderRequest {
     }
 }
 
-impl ::std::fmt::Debug for TransferLeaderRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TransferLeaderRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct TransferLeaderResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -4704,19 +4554,13 @@ impl ::protobuf::Clear for TransferLeaderResponse {
     }
 }
 
-impl ::std::fmt::Debug for TransferLeaderResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for TransferLeaderResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct VerifyHashRequest {
     // message fields
     pub index: u64,
@@ -4875,19 +4719,13 @@ impl ::protobuf::Clear for VerifyHashRequest {
     }
 }
 
-impl ::std::fmt::Debug for VerifyHashRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for VerifyHashRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct VerifyHashResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -4978,19 +4816,13 @@ impl ::protobuf::Clear for VerifyHashResponse {
     }
 }
 
-impl ::std::fmt::Debug for VerifyHashResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for VerifyHashResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrepareMergeRequest {
     // message fields
     pub min_index: u64,
@@ -5164,19 +4996,13 @@ impl ::protobuf::Clear for PrepareMergeRequest {
     }
 }
 
-impl ::std::fmt::Debug for PrepareMergeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrepareMergeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct PrepareMergeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -5267,19 +5093,13 @@ impl ::protobuf::Clear for PrepareMergeResponse {
     }
 }
 
-impl ::std::fmt::Debug for PrepareMergeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for PrepareMergeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CommitMergeRequest {
     // message fields
     pub source: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -5497,19 +5317,13 @@ impl ::protobuf::Clear for CommitMergeRequest {
     }
 }
 
-impl ::std::fmt::Debug for CommitMergeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CommitMergeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct CommitMergeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -5600,19 +5414,13 @@ impl ::protobuf::Clear for CommitMergeResponse {
     }
 }
 
-impl ::std::fmt::Debug for CommitMergeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for CommitMergeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RollbackMergeRequest {
     // message fields
     pub commit: u64,
@@ -5734,19 +5542,13 @@ impl ::protobuf::Clear for RollbackMergeRequest {
     }
 }
 
-impl ::std::fmt::Debug for RollbackMergeRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RollbackMergeRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RollbackMergeResponse {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -5837,19 +5639,13 @@ impl ::protobuf::Clear for RollbackMergeResponse {
     }
 }
 
-impl ::std::fmt::Debug for RollbackMergeResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RollbackMergeResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AdminRequest {
     // message fields
     pub cmd_type: AdminCmdType,
@@ -6435,19 +6231,13 @@ impl ::protobuf::Clear for AdminRequest {
     }
 }
 
-impl ::std::fmt::Debug for AdminRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AdminRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct AdminResponse {
     // message fields
     pub cmd_type: AdminCmdType,
@@ -7033,19 +6823,13 @@ impl ::protobuf::Clear for AdminResponse {
     }
 }
 
-impl ::std::fmt::Debug for AdminResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for AdminResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionLeaderRequest {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -7136,19 +6920,13 @@ impl ::protobuf::Clear for RegionLeaderRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionLeaderRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionLeaderRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionLeaderResponse {
     // message fields
     pub leader: ::protobuf::SingularPtrField<super::metapb::Peer>,
@@ -7292,19 +7070,13 @@ impl ::protobuf::Clear for RegionLeaderResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionLeaderResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionLeaderResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionDetailRequest {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -7395,19 +7167,13 @@ impl ::protobuf::Clear for RegionDetailRequest {
     }
 }
 
-impl ::std::fmt::Debug for RegionDetailRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionDetailRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionDetailResponse {
     // message fields
     pub region: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -7603,19 +7369,13 @@ impl ::protobuf::Clear for RegionDetailResponse {
     }
 }
 
-impl ::std::fmt::Debug for RegionDetailResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RegionDetailResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StatusRequest {
     // message fields
     pub cmd_type: StatusCmdType,
@@ -7837,19 +7597,13 @@ impl ::protobuf::Clear for StatusRequest {
     }
 }
 
-impl ::std::fmt::Debug for StatusRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StatusRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StatusResponse {
     // message fields
     pub cmd_type: StatusCmdType,
@@ -8071,19 +7825,13 @@ impl ::protobuf::Clear for StatusResponse {
     }
 }
 
-impl ::std::fmt::Debug for StatusResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StatusResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftRequestHeader {
     // message fields
     pub region_id: u64,
@@ -8436,19 +8184,13 @@ impl ::protobuf::Clear for RaftRequestHeader {
     }
 }
 
-impl ::std::fmt::Debug for RaftRequestHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftRequestHeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftResponseHeader {
     // message fields
     pub error: ::protobuf::SingularPtrField<super::errorpb::Error>,
@@ -8659,19 +8401,13 @@ impl ::protobuf::Clear for RaftResponseHeader {
     }
 }
 
-impl ::std::fmt::Debug for RaftResponseHeader {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftResponseHeader {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftCmdRequest {
     // message fields
     pub header: ::protobuf::SingularPtrField<RaftRequestHeader>,
@@ -8963,19 +8699,13 @@ impl ::protobuf::Clear for RaftCmdRequest {
     }
 }
 
-impl ::std::fmt::Debug for RaftCmdRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftCmdRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftCmdResponse {
     // message fields
     pub header: ::protobuf::SingularPtrField<RaftResponseHeader>,
@@ -9264,12 +8994,6 @@ impl ::protobuf::Clear for RaftCmdResponse {
         self.clear_admin_response();
         self.clear_status_response();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for RaftCmdResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/raft_serverpb.rs
+++ b/src/protobuf/raft_serverpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftMessage {
     // message fields
     pub region_id: u64,
@@ -507,19 +507,13 @@ impl ::protobuf::Clear for RaftMessage {
     }
 }
 
-impl ::std::fmt::Debug for RaftMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftMessage {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftTruncatedState {
     // message fields
     pub index: u64,
@@ -671,19 +665,13 @@ impl ::protobuf::Clear for RaftTruncatedState {
     }
 }
 
-impl ::std::fmt::Debug for RaftTruncatedState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftTruncatedState {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SnapshotCFFile {
     // message fields
     pub cf: ::std::string::String,
@@ -872,19 +860,13 @@ impl ::protobuf::Clear for SnapshotCFFile {
     }
 }
 
-impl ::std::fmt::Debug for SnapshotCFFile {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SnapshotCFFile {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SnapshotMeta {
     // message fields
     pub cf_files: ::protobuf::RepeatedField<SnapshotCFFile>,
@@ -1020,19 +1002,13 @@ impl ::protobuf::Clear for SnapshotMeta {
     }
 }
 
-impl ::std::fmt::Debug for SnapshotMeta {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SnapshotMeta {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct SnapshotChunk {
     // message fields
     pub message: ::protobuf::SingularPtrField<RaftMessage>,
@@ -1213,19 +1189,13 @@ impl ::protobuf::Clear for SnapshotChunk {
     }
 }
 
-impl ::std::fmt::Debug for SnapshotChunk {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for SnapshotChunk {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct Done {
     // special fields
     unknown_fields: ::protobuf::UnknownFields,
@@ -1316,19 +1286,13 @@ impl ::protobuf::Clear for Done {
     }
 }
 
-impl ::std::fmt::Debug for Done {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for Done {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct KeyValue {
     // message fields
     pub key: ::std::vec::Vec<u8>,
@@ -1494,19 +1458,13 @@ impl ::protobuf::Clear for KeyValue {
     }
 }
 
-impl ::std::fmt::Debug for KeyValue {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for KeyValue {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftSnapshotData {
     // message fields
     pub region: ::protobuf::SingularPtrField<super::metapb::Region>,
@@ -1806,19 +1764,13 @@ impl ::protobuf::Clear for RaftSnapshotData {
     }
 }
 
-impl ::std::fmt::Debug for RaftSnapshotData {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftSnapshotData {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct StoreIdent {
     // message fields
     pub cluster_id: u64,
@@ -1970,19 +1922,13 @@ impl ::protobuf::Clear for StoreIdent {
     }
 }
 
-impl ::std::fmt::Debug for StoreIdent {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for StoreIdent {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftLocalState {
     // message fields
     pub hard_state: ::protobuf::SingularPtrField<super::eraftpb::HardState>,
@@ -2156,19 +2102,13 @@ impl ::protobuf::Clear for RaftLocalState {
     }
 }
 
-impl ::std::fmt::Debug for RaftLocalState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftLocalState {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RaftApplyState {
     // message fields
     pub applied_index: u64,
@@ -2342,19 +2282,13 @@ impl ::protobuf::Clear for RaftApplyState {
     }
 }
 
-impl ::std::fmt::Debug for RaftApplyState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for RaftApplyState {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct MergeState {
     // message fields
     pub min_index: u64,
@@ -2558,19 +2492,13 @@ impl ::protobuf::Clear for MergeState {
     }
 }
 
-impl ::std::fmt::Debug for MergeState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for MergeState {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct RegionLocalState {
     // message fields
     pub state: PeerState,
@@ -2789,12 +2717,6 @@ impl ::protobuf::Clear for RegionLocalState {
         self.clear_region();
         self.clear_merge_state();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for RegionLocalState {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 

--- a/src/protobuf/tikvpb.rs
+++ b/src/protobuf/tikvpb.rs
@@ -21,7 +21,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchCommandsRequest {
     // message fields
     pub requests: ::protobuf::RepeatedField<BatchCommandsRequest_Request>,
@@ -193,19 +193,13 @@ impl ::protobuf::Clear for BatchCommandsRequest {
     }
 }
 
-impl ::std::fmt::Debug for BatchCommandsRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchCommandsRequest {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchCommandsRequest_Request {
     // message oneof groups
     pub cmd: ::std::option::Option<BatchCommandsRequest_Request_oneof_cmd>,
@@ -214,7 +208,7 @@ pub struct BatchCommandsRequest_Request {
     cached_size: ::protobuf::CachedSize,
 }
 
-#[derive(Clone,PartialEq)]
+#[derive(Clone,PartialEq,Debug)]
 pub enum BatchCommandsRequest_Request_oneof_cmd {
     Get(super::kvrpcpb::GetRequest),
     Scan(super::kvrpcpb::ScanRequest),
@@ -1872,19 +1866,13 @@ impl ::protobuf::Clear for BatchCommandsRequest_Request {
     }
 }
 
-impl ::std::fmt::Debug for BatchCommandsRequest_Request {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchCommandsRequest_Request {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchCommandsResponse {
     // message fields
     pub responses: ::protobuf::RepeatedField<BatchCommandsResponse_Response>,
@@ -2086,19 +2074,13 @@ impl ::protobuf::Clear for BatchCommandsResponse {
     }
 }
 
-impl ::std::fmt::Debug for BatchCommandsResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchCommandsResponse {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchCommandsResponse_Response {
     // message oneof groups
     pub cmd: ::std::option::Option<BatchCommandsResponse_Response_oneof_cmd>,
@@ -2107,7 +2089,7 @@ pub struct BatchCommandsResponse_Response {
     cached_size: ::protobuf::CachedSize,
 }
 
-#[derive(Clone,PartialEq)]
+#[derive(Clone,PartialEq,Debug)]
 pub enum BatchCommandsResponse_Response_oneof_cmd {
     Get(super::kvrpcpb::GetResponse),
     Scan(super::kvrpcpb::ScanResponse),
@@ -3765,19 +3747,13 @@ impl ::protobuf::Clear for BatchCommandsResponse_Response {
     }
 }
 
-impl ::std::fmt::Debug for BatchCommandsResponse_Response {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
 impl ::protobuf::reflect::ProtobufValue for BatchCommandsResponse_Response {
     fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq,Clone,Default,Debug)]
 pub struct BatchRaftMessage {
     // message fields
     pub msgs: ::protobuf::RepeatedField<super::raft_serverpb::RaftMessage>,
@@ -3910,12 +3886,6 @@ impl ::protobuf::Clear for BatchRaftMessage {
     fn clear(&mut self) {
         self.clear_msgs();
         self.unknown_fields.clear();
-    }
-}
-
-impl ::std::fmt::Debug for BatchRaftMessage {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
This reverts commit c982a6770367b4106c17bc454159180e9853f35b.

Custom debug requires descriptor, we need to think of another way to fix it.