### PR TITLE
Fix the build by using a specific git commit for raft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ prost-derive = "0.5"
 bytes = "0.4"
 futures = "0.1"
 grpcio = { version = "0.5.0-alpha.1", features = ["prost-codec"] }
-raft = "0.4.1"
+raft = { git = "https://github.com/pingcap/raft-rs.git", rev = "7c5bdfc58d23860ad6111fbbfe1d4db1d4c3d894" }
 lazy_static = "1.3"
 
 [build-dependencies]


### PR DESCRIPTION
Since we yanked 0.4.1, kvproto would not build because it would try to pull 0.4.2 which lacks Prost support. This change points to a specific git commit which includes Prost support