### PR TITLE
txn: generate check_not_exists op in rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,5 @@ curl -L https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/pr
 unzip protoc.zip -d protoc &&\
 rm protoc.zip
 ```
-
 Then you can run `PATH="$(pwd)/protoc/bin:$PATH" make`
 

--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ curl -L https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/pr
 unzip protoc.zip -d protoc &&\
 rm protoc.zip
 ```
+
 Then you can run `PATH="$(pwd)/protoc/bin:$PATH" make`
 

--- a/src/protobuf/kvrpcpb.rs
+++ b/src/protobuf/kvrpcpb.rs
@@ -19425,6 +19425,7 @@ pub enum Op {
     Rollback = 3,
     Insert = 4,
     PessimisticLock = 5,
+    CheckNotExists = 6,
 }
 
 impl ::protobuf::ProtobufEnum for Op {
@@ -19440,6 +19441,7 @@ impl ::protobuf::ProtobufEnum for Op {
             3 => ::std::option::Option::Some(Op::Rollback),
             4 => ::std::option::Option::Some(Op::Insert),
             5 => ::std::option::Option::Some(Op::PessimisticLock),
+            6 => ::std::option::Option::Some(Op::CheckNotExists),
             _ => ::std::option::Option::None
         }
     }
@@ -19452,6 +19454,7 @@ impl ::protobuf::ProtobufEnum for Op {
             Op::Rollback,
             Op::Insert,
             Op::PessimisticLock,
+            Op::CheckNotExists,
         ];
         values
     }


### PR DESCRIPTION
generate .rs file for #565 in 3.0

.... in master we no need `make rust` in kvproto and autogenerate when tikv compile, but for 3.0 still need `make rust`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/kvproto/571)
<!-- Reviewable:end -->
