### PR TITLE
Revert "upgrade dependencies"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ Cargo.lock
 _tools
 
 cpp/kvproto/*
-.DS_Store
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ raft-proto = { version = "0.6.0-alpha", default-features = false }
 lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
-protobuf-build = { version = "0.11.3", default-features = false }
+protobuf-build = { version = "=0.11.3", default-features = false }
 
 [patch.crates-io]
 raft-proto = { git = "https://github.com/tikv/raft-rs", rev = "e624c1d48460940a40d8aa69b5329460d9af87dd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ raft-proto = { version = "0.6.0-alpha", default-features = false }
 lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
-protobuf-build = { version = "0.11", default-features = false }
+protobuf-build = { version = "0.11.3", default-features = false }
 
 [patch.crates-io]
 raft-proto = { git = "https://github.com/tikv/raft-rs", rev = "e624c1d48460940a40d8aa69b5329460d9af87dd" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ prost-codec = ["prost", "prost-derive", "lazy_static", "protobuf-build/grpcio-pr
 protobuf = "=2.8.0"
 prost = { version = "0.6", optional = true }
 prost-derive = { version = "0.6", optional = true }
-futures = "0.3.5"
-grpcio = { version = "0.6.0", default-features = false, features = ["secure"] }
+futures = "0.1"
+grpcio = { version = "0.5.0", default-features = false, features = ["secure"] }
 raft-proto = { version = "0.6.0-alpha", default-features = false }
 lazy_static = { version = "1.3", optional = true }
 


### PR DESCRIPTION
kvproto#631 blocks other PR to update kvproto. Let's merge it after other components have been updated.
