### PR TITLE
shell script fixes and debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ all: go rust c++
 
 init:
 	mkdir -p $(CURDIR)/bin
+
 check: init
 	$(CURDIR)/scripts/check.sh
+
 go: check
 	# Standalone GOPATH
 	$(CURDIR)/scripts/generate_go.sh
@@ -17,8 +19,8 @@ go: check
 	GO111MODULE=on go build ./pkg/...
 
 rust: init
-	cargo check
-	cargo check --no-default-features --features prost-codec
+	cargo check \
+	&& cargo check --no-default-features --features prost-codec
 
 c++: check
 	$(CURDIR)/scripts/generate_cpp.sh

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-check_protoc_version() {
-    version=$(protoc --version)
-    major=$(echo ${version} | sed -n -e 's/.*\([0-9]\{1,\}\)\.[0-9]\{1,\}\.[0-9]\{1,\}.*/\1/p')
-    minor=$(echo ${version} | sed -n -e 's/.*[0-9]\{1,\}\.\([0-9]\{1,\}\)\.[0-9]\{1,\}.*/\1/p')
-    if [ "$major" -eq 3 ] && [ "$minor" -eq 8 ]; then
-	    return 0
-    fi
-    echo "protoc version not match, version 3.8.x is needed, current version: ${version}"
-    return 1
-}
+if ! version=$(protoc --version) ; then
+	echo ""
+	echo "    could not find protoc"
+	exit 1
+fi
 
-if ! check_protoc_version; then
+major=$(echo ${version} | sed -n -e 's/.*\([0-9]\{1,\}\)\.[0-9]\{1,\}\.[0-9]\{1,\}.*/\1/p')
+minor=$(echo ${version} | sed -n -e 's/.*[0-9]\{1,\}\.\([0-9]\{1,\}\)\.[0-9]\{1,\}.*/\1/p')
+if ! [ "$major" -eq 3 ] || ! [ "$minor" -eq 8 ]; then
+	echo "protoc version not match, version 3.8.x is needed, current version: ${version}"
 	exit 1
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-function push() {
-    pushd $1 >/dev/null 2>&1
-}
-
-function pop() {
-    popd $1 >/dev/null 2>&1
-}
-
 function sed_inplace()
 {
 	if [ `uname` == "Darwin" ]; then

--- a/scripts/generate_cpp.sh
+++ b/scripts/generate_cpp.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+SHELL_DEBUG=${SHELL_DEBUG:-""}
+if [[ -n "$SHELL_DEBUG" ]] ; then
+  set -x
+fi
 
 SCRIPTS_DIR=$(dirname "$0")
 source $SCRIPTS_DIR/common.sh
@@ -18,13 +24,13 @@ sed_inplace '/gogo.proto/d' proto-cpp/*
 sed_inplace '/option\ *(gogoproto/d' proto-cpp/*
 sed_inplace -e 's/\[.*gogoproto.*\]//g' proto-cpp/*
 
-push proto-cpp
-protoc -I${GRPC_INCLUDE} --cpp_out ../cpp/kvproto *.proto || exit $?
-protoc -I${GRPC_INCLUDE} --grpc_out ../cpp/kvproto --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` *.proto || exit $?
-pop
+pushd proto-cpp >/dev/null
+protoc -I${GRPC_INCLUDE} --cpp_out ../cpp/kvproto *.proto
+protoc -I${GRPC_INCLUDE} --grpc_out ../cpp/kvproto --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` *.proto
+popd >/dev/null
 
-push include
-protoc -I${GRPC_INCLUDE} --cpp_out ../cpp/kvproto *.proto google/api/http.proto google/api/annotations.proto || exit $?
-pop
+pushd include >/dev/null
+protoc -I${GRPC_INCLUDE} --cpp_out ../cpp/kvproto *.proto google/api/http.proto google/api/annotations.proto
+popd >/dev/null
 
 rm -rf proto-cpp


### PR DESCRIPTION
Use `set -eu` and alter scripts accordingly. This catches several ignored errors.
Also add an environment variable SHELL_DEBUG to add `set -x`.

Currently I cannot build this project on several different environments I can successfully run `make rust` on one environment. But go and c++ don't fail for me until the end of the generate script so I think this is all working. But it would be great if someone else could run this branch as well.

Signed-off-by: Greg Weber <greg@pingcap.com>