### PR TITLE
add `allowed_on_disk_full` field for message Context

### DIFF
--- a/proto/kvrpcpb.proto
+++ b/proto/kvrpcpb.proto
@@ -685,6 +685,9 @@ message Context {
 
     // Any additional serialized information about the request.
     bytes resource_group_tag = 18;
+
+    // Flag used to tell tikv that operations can be allowed even when tikv disk full happens.
+    bool allowed_on_disk_full = 19;
 }
 
 message LockInfo {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number：close #784

###  What is changed and how it works?

1. add a flag used by tidb to tell tikv which operation can be allowed when tikv disk full happens.

### Check List

not available

### Release note

not available