### PR TITLE
Fix cpp include header path

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -124,10 +124,10 @@ set_source_files_properties(
 add_library(kvproto
     ${PROTO_SRCS} ${PROTO_HDRS}
 )
-target_include_directories(kvproto
-    PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${PROTO_OUTPUT_DIR}
+target_include_directories(kvproto PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
+    # Need this to find headers "google/api/http.pb.h" "google/api/annotations.pb.h"
+    ${CMAKE_CURRENT_BINARY_DIR}/kvproto
     ${Protobuf_INCLUDE_DIR}
     ${gRPC_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

Problem Summary:
In https://github.com/pingcap/kvproto/pull/955, we generate the .pb.h, .pb.cc files under "${CMAKE_CURRENT_BINARY_DIR}/kvproto", and also set the include path to it. That's not right because we include headers by using `#include <kvproto/coprocessor.pb.h>` in C++ code.

Ref https://github.com/pingcap/tipb/pull/273