### PR TITLE
Upgrade C++ grpc version to 1.44

### DIFF
--- a/.github/workflows/cpp-test.yaml
+++ b/.github/workflows/cpp-test.yaml
@@ -22,21 +22,21 @@ jobs:
         run: sudo apt install -y cmake clang libclang-dev llvm llvm-dev
       - name: Cache gRPC
         id: cache-grpc
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ~/grpcinstall/v1_26_0
-          key: ${{ runner.os }}-gRPC-v1_26_0-t0
+          path: ~/grpcinstall/v1_44_0
+          key: ${{ runner.os }}-gRPC-v1_44_0-t0
       - name: Install gRPC
         if: steps.cache-grpc.outputs.cache-hit != 'true'
         run: |
-          export GRPC_INSTALL_PATH=~/grpcinstall/v1_26_0 && mkdir -p $GRPC_INSTALL_PATH
+          export GRPC_INSTALL_PATH=~/grpcinstall/v1_44_0 && mkdir -p $GRPC_INSTALL_PATH
           git clone https://github.com/grpc/grpc.git
-          pushd grpc && git checkout v1.26.0 && git submodule update --init
+          pushd grpc && git checkout v1.44.0 && git submodule update --init
           mkdir -p grpcbuild && pushd grpcbuild && cmake .. -DgRPC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_PATH && make install && popd
           rm -rf grpcbuild && mkdir -p grpcbuild && pushd grpcbuild && cmake .. -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL_PATH && make install && popd
           popd
       - name: Test C++
         run: |
-          export GRPC_INSTALL_PATH=~/grpcinstall/v1_26_0
+          export GRPC_INSTALL_PATH=~/grpcinstall/v1_44_0
           export PATH="$GRPC_INSTALL_PATH/bin:$PATH"
           rm -rf kvprotobuild && mkdir kvprotobuild && pushd kvprotobuild && cmake ../cpp -DCMAKE_PREFIX_PATH=$GRPC_INSTALL_PATH && make && popd && rm -rf kvprotobuild

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,7 @@ Cargo.lock
 .idea
 _tools
 
-cpp/
-!cpp/cmake/
-!cpp/CMakeLists.txt
+cpp/kvproto/
 proto-cpp/
 kvprotobuild
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 project (kvproto)
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.5)
 
 set (CMAKE_CXX_STANDARD 17)
 
@@ -20,6 +20,10 @@ endif ()
 
 if (NOT gRPC_FOUND)
     include (cmake/find_grpc.cmake)
+endif ()
+
+if (NOT ABSL_ROOT_DIR)
+    include (cmake/find_abseil-cpp.cmake)
 endif ()
 
 # .proto files under "proto"
@@ -123,6 +127,9 @@ set_source_files_properties(
 
 add_library(kvproto
     ${PROTO_SRCS} ${PROTO_HDRS}
+)
+target_link_libraries(kvproto
+    absl::synchronization
 )
 target_include_directories(kvproto PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}

--- a/cpp/cmake/find_abseil-cpp.cmake
+++ b/cpp/cmake/find_abseil-cpp.cmake
@@ -1,2 +1,2 @@
 find_package(absl REQUIRED)
-message(STATUS "Using absl: ${absl_DIR}")
+message(STATUS "Using absl: dir=${absl_DIR}, version=${absl_VERSION}")

--- a/cpp/cmake/find_abseil-cpp.cmake
+++ b/cpp/cmake/find_abseil-cpp.cmake
@@ -1,0 +1,2 @@
+find_package(absl REQUIRED)
+message(STATUS "Using absl: ${absl_DIR}")


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

The header files of grpc depends on absl library since some version.
Build error: https://ci.pingcap.net/blue/organizations/jenkins/tiflash-build-common/detail/tiflash-build-common/11206/pipeline/

Ref: https://github.com/grpc/grpc/pull/26802
