### PR TITLE
raft_serverpb: add new ExtraMessage types for the snapshot gen precheck process

### DIFF
--- a/proto/raft_serverpb.proto
+++ b/proto/raft_serverpb.proto
@@ -252,6 +252,9 @@ enum ExtraMessageType {
     MsgGcPeerResponse = 12;
     MsgFlushMemtable = 13;
     MsgRefreshBuckets = 14;
+
+    MsgSnapshotSendPrecheckRequest = 15;
+    MsgSnapshotSendPrecheckResponse = 16;
 }
 
 message FlushMemtable {
@@ -293,4 +296,6 @@ message ExtraMessage {
     AvailabilityContext availability_context = 8;
     // notice the peer to refresh buckets version
     RefreshBuckets refresh_buckets = 9;
+    // token for snapshot sending
+    string SnapshotSendToken = 10;
 }

--- a/proto/raft_serverpb.proto
+++ b/proto/raft_serverpb.proto
@@ -296,6 +296,7 @@ message ExtraMessage {
     AvailabilityContext availability_context = 8;
     // notice the peer to refresh buckets version
     RefreshBuckets refresh_buckets = 9;
-    // token for snapshot sending
-    string SnapshotSendToken = 10;
+    // A snapshot is only sent by the leader after this precheck, conducted on 
+    // the follower, has successfully passed. 
+    bool snapshot_precheck_passed = 10;
 }

--- a/proto/raft_serverpb.proto
+++ b/proto/raft_serverpb.proto
@@ -296,7 +296,7 @@ message ExtraMessage {
     AvailabilityContext availability_context = 8;
     // notice the peer to refresh buckets version
     RefreshBuckets refresh_buckets = 9;
-    // snapshot_gen_precheck_passed is used to indicate the precheck result when
-    // a follower responds to a leader's precheck request.
-    bool snapshot_gen_precheck_passed = 10;
+    // snap_gen_precheck_passed is used to indicate the precheck result when
+    // a follower responds to a leader's snapshot gen precheck request.
+    bool snap_gen_precheck_passed = 10;
 }

--- a/proto/raft_serverpb.proto
+++ b/proto/raft_serverpb.proto
@@ -252,9 +252,9 @@ enum ExtraMessageType {
     MsgGcPeerResponse = 12;
     MsgFlushMemtable = 13;
     MsgRefreshBuckets = 14;
-
-    MsgSnapshotSendPrecheckRequest = 15;
-    MsgSnapshotSendPrecheckResponse = 16;
+    // Messages for the snapshot gen precheck process.
+    MsgSnapGenPrecheckRequest = 15;
+    MsgSnapGenPrecheckResponse = 16;
 }
 
 message FlushMemtable {
@@ -296,7 +296,7 @@ message ExtraMessage {
     AvailabilityContext availability_context = 8;
     // notice the peer to refresh buckets version
     RefreshBuckets refresh_buckets = 9;
-    // A snapshot is only sent by the leader after this precheck, conducted on 
-    // the follower, has successfully passed. 
-    bool snapshot_precheck_passed = 10;
+    // snapshot_gen_precheck_passed is used to indicate the precheck result when
+    // a follower responds to a leader's precheck request.
+    bool snapshot_gen_precheck_passed = 10;
 }

--- a/scripts/proto.lock
+++ b/scripts/proto.lock
@@ -17491,6 +17491,14 @@
               {
                 "name": "MsgRefreshBuckets",
                 "integer": 14
+              },
+              {
+                "name": "MsgSnapGenPrecheckRequest",
+                "integer": 15
+              },
+              {
+                "name": "MsgSnapGenPrecheckResponse",
+                "integer": 16
               }
             ]
           }
@@ -18199,6 +18207,11 @@
                 "id": 9,
                 "name": "refresh_buckets",
                 "type": "RefreshBuckets"
+              },
+              {
+                "id": 10,
+                "name": "snap_gen_precheck_passed",
+                "type": "bool"
               }
             ]
           }


### PR DESCRIPTION
Related issue: https://github.com/tikv/tikv/issues/15972

This commit adds two new new ExtraMessage types that are part of the snapshot
gen precheck process: Before a leader generates a snapshot, it sends a precheck
request to the target follower. The follower responds with a boolean value
indicating whether the check succeeds. 