### PR TITLE
Lock Ubuntu at 22.04 for CPP / Rust Test Workflow

### DIFF
--- a/.github/workflows/cpp-test.yaml
+++ b/.github/workflows/cpp-test.yaml
@@ -14,7 +14,7 @@ on:
       - release-4.0
 jobs:
   cpp-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -16,7 +16,7 @@ on:
       - release-3.0
 jobs:
   rust-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #[allow(renamed_and_removed_lints)]
 #[allow(bare_trait_objects)]
 #[allow(deprecated)]
+#[allow(static_mut_refs)]
+
 mod protos {
     include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));
 


### PR DESCRIPTION
For now test/cpp and test/rust cannot pass due to `llvm` and `gcc` are updated.