### PR TITLE
ci: declare workflow-level `contents: read` on golang-test and rust-test

### DIFF
--- a/.github/workflows/golang-test.yaml
+++ b/.github/workflows/golang-test.yaml
@@ -10,6 +10,9 @@ on:
       - master
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   golang-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -10,6 +10,9 @@ on:
       - master
       - release-*
 
+permissions:
+  contents: read
+
 jobs:
   rust-test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the Go and Rust test workflows. Both only run language test suites; no GitHub API writes.

`cpp-test.yaml` is intentionally untouched since it uses `actions/cache@v3` directly (would need `actions: write` for the cache save path, scope decision belongs to maintainers).

Same hardening shape as the post-CVE-2025-30066 response (`tj-actions/changed-files` compromise). YAML validated locally.